### PR TITLE
Prohibit additional properties in schema definitions

### DIFF
--- a/OpenAPIv3/schema-generator/main.go
+++ b/OpenAPIv3/schema-generator/main.go
@@ -462,6 +462,8 @@ func buildSchemaWithModel(modelObject *SchemaObject) (schema *jsonschema.Schema)
 		schema.Required = &arrayCopy
 	}
 
+	schema.AdditionalProperties = jsonschema.NewSchemaOrBooleanWithBoolean(false);
+
 	schema.Description = stringptr(modelObject.Description)
 
 	// handle fixed fields


### PR DESCRIPTION
Prohibit additional properties in schema definitions, otherwise, the JSON schema is too permissive. 
OpenAPI v3 specification provides [specification extensions](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#specificationExtensions) to define additional (custom) properties.

## False validation errors with current JSON Schema
A too permissive schema can also cause false negatives (false validation errors) on a valid OpenAPI v3 specification. Let's take this example, it's simplified version of [PetStore](https://github.com/OAI/OpenAPI-Specification/pull/985/files#diff-4530232d2a5e2e4be11ab57cd8ba8894):
```yaml
openapi: "3.0.0"
info:
  version: 1.0.0
  title: Swagger Petstore
  license:
    name: MIT
paths: {}

components:
  schemas:
    Pet:
      properties:
        name:
          type: string
    Pets:
      type: array
      items:
        $ref: "#/components/schemas/Pet"
```
Current JSON Schema will cause an error on line 18 (`$ref: "#/components/schemas/Pet"`):
```
	Failed to match exactly one schema:
	 - /definitions/schemaOrReference/oneOf/0:
	 - /definitions/schemaOrReference/oneOf/1:
```
The problem is that it matches **both** `#/definitions/schema` and `#/definitions/reference` schemas, while exactly **one** match is allowed in this case. And our `$ref` matches `#/definitions/schema` because the `#/definitions/schema` definition did not prohibit additional properties. Similarly in other cases.

--------------------------------------
Thank you for creating this JSON Schema! #