### PR TITLE
Fix regex in patternProperties

### DIFF
--- a/OpenAPIv3/openapi-3.0.json
+++ b/OpenAPIv3/openapi-3.0.json
@@ -153,7 +153,7 @@
       "type": "object",
       "description": "",
       "patternProperties": {
-        "{name}": {
+        "^[a-zA-Z0-9\\.\\-_]+$": {
           "$ref": "#/definitions/serverVariable"
         },
         "^x-": {
@@ -230,7 +230,7 @@
       "type": "object",
       "description": "Holds the relative paths to the individual endpoints and their operations. The path is appended to the URL from the `Server Object` in order to construct the full URL.  The Paths MAY be empty, due to ACL constraints.",
       "patternProperties": {
-        "/{path}": {
+        "^/": {
           "$ref": "#/definitions/pathItem"
         },
         "^x-": {
@@ -463,7 +463,7 @@
       "type": "object",
       "description": "Describes a set of supported media types. A Content Object can be used in Request Body Object, Parameter Objects, Header Objects, and Response Objects.",
       "patternProperties": {
-        "{media-type}": {
+        "^": {
           "$ref": "#/definitions/mediaType"
         }
       }
@@ -495,7 +495,7 @@
       "type": "object",
       "description": "An object representing multipart region encoding for `requestBody` objects.",
       "patternProperties": {
-        "{property}": {
+        "^": {
           "$ref": "#/definitions/encodingProperty"
         }
       }
@@ -573,7 +573,7 @@
       "type": "object",
       "description": "A map of possible out-of band callbacks related to the parent operation. Each value in the map is a Callback Object that describes a request that may be initiated by the API provider and the expected responses. The key value used to identify the callback object is an expression, evaluated at runtime, that identifies a URL to use for the callback operation.",
       "patternProperties": {
-        "{name}": {
+        "^[a-zA-Z0-9\\.\\-_]+$": {
           "$ref": "#/definitions/callbackOrReference"
         },
         "^x-": {
@@ -585,7 +585,7 @@
       "type": "object",
       "description": "A map of possible out-of band callbacks related to the parent operation. Each value in the map is a Path Item Object that describes a set of requests that may be initiated by the API provider and the expected responses. The key value used to identify the callback object is an expression, evaluated at runtime, that identifies a URL to use for the callback operation.",
       "patternProperties": {
-        "{expression}": {
+        "^": {
           "$ref": "#/definitions/pathItem"
         },
         "^x-": {
@@ -597,7 +597,7 @@
       "type": "object",
       "description": "Lists the headers that can be sent in a response or forwarded via a link. Note that RFC 7230 states header names are case insensitive.",
       "patternProperties": {
-        "{name}": {
+        "^[a-zA-Z0-9\\.\\-_]+$": {
           "$ref": "#/definitions/headerOrReference"
         }
       }
@@ -629,7 +629,7 @@
       "type": "object",
       "description": "The links object represents a set of possible design-time links for a response. The presence of a link does not guarantee the caller's ability to successfully invoke it, rather it provides a known relationship and traversal mechanism between responses and other operations.  As opposed to _dynamic_ links (links provided **in** the response payload), the OAS linking mechanism does not require that link information be provided in a specific response format at runtime.  For computing links, and providing instructions to execute them, variable substitution is used for accessing values in a response and using them as values while invoking the linked operation.",
       "patternProperties": {
-        "{name}": {
+        "^[a-zA-Z0-9\\.\\-_]+$": {
           "$ref": "#/definitions/linkOrReference"
         }
       }
@@ -667,7 +667,7 @@
       "type": "object",
       "description": "Using the `operationId` to reference an operation in the definition has many benefits, including the ability to define media type options, security requirements, response and error payloads. Many operations require parameters to be passed, and these MAY be dynamic depending on the response itself.  To specify parameters required by the operation, we can use a **Link Parameters Object**. This object contains parameter names along with static or dynamic values:",
       "patternProperties": {
-        "{name}": {
+        "^[a-zA-Z0-9\\.\\-_]+$": {
           "$ref": "#/definitions/anyOrExpression"
         }
       }
@@ -1020,7 +1020,7 @@
       "type": "object",
       "description": "Lists the available scopes for an OAuth2 security scheme.",
       "patternProperties": {
-        "{name}": {
+        "^[a-zA-Z0-9\\.\\-_]+$": {
           "type": "string"
         },
         "^x-": {
@@ -1032,7 +1032,7 @@
       "type": "object",
       "description": "Lists the required security schemes to execute this operation. The name used for each property MUST correspond to a security scheme declared in the Security Schemes under the Components Object.  Security Requirement Objects that contain multiple schemes require that all schemes MUST be satisfied for a request to be authorized. This enables support for scenarios where there multiple query parameters or HTTP headers are required to convey security information.  When a list of Security Requirement Objects is defined on the Open API object or Operation Object, only one of Security Requirement Objects in the list needs to be satisfied to authorize.",
       "patternProperties": {
-        "{name}": {
+        "^[a-zA-Z0-9\\.\\-_]+$": {
           "type": "array",
           "items": {
             "type": "string"

--- a/OpenAPIv3/schema-generator/main.go
+++ b/OpenAPIv3/schema-generator/main.go
@@ -520,6 +520,9 @@ func buildSchemaWithModel(modelObject *SchemaObject) (schema *jsonschema.Schema)
 				// Component names should match "^[a-zA-Z0-9\.\-_]+$"
 				// See https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#componentsObject
 				propertyName := strings.Replace(modelField.Name, "{name}", "^[a-zA-Z0-9\\\\.\\\\-_]+$", -1)
+				//  The field name MUST begin with a slash, see https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#paths-object
+				// JSON Schema for OpenAPI v2 uses "^/" as regex for paths, see https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/schemas/v2.0/schema.json#L173
+				propertyName = strings.Replace(propertyName, "/{path}", "^/", -1)
 				// Replace human-friendly (and regex-confusing) description with a blank pattern
 				propertyName = strings.Replace(propertyName, "{expression}", "^", -1)
 				propertyName = strings.Replace(propertyName, "{property}", "^", -1)

--- a/OpenAPIv3/schema-generator/main.go
+++ b/OpenAPIv3/schema-generator/main.go
@@ -517,7 +517,10 @@ func buildSchemaWithModel(modelObject *SchemaObject) (schema *jsonschema.Schema)
 			if schemaField == nil {
 				// create and add the schema field
 				schemaField = &jsonschema.Schema{}
-				namedSchema := &jsonschema.NamedSchema{Name: modelField.Name, Value: schemaField}
+				// Component names should match "^[a-zA-Z0-9\.\-_]+$"
+				// See https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#componentsObject
+				propertyName := strings.Replace(modelField.Name, "{name}", "^[a-zA-Z0-9\\\\.\\\\-_]+$", -1)
+				namedSchema := &jsonschema.NamedSchema{Name: propertyName, Value: schemaField}
 				newNamedSchemas = append(newNamedSchemas, namedSchema)
 			}
 			updateSchemaFieldWithModelField(schemaField, &modelField)

--- a/OpenAPIv3/schema-generator/main.go
+++ b/OpenAPIv3/schema-generator/main.go
@@ -520,6 +520,9 @@ func buildSchemaWithModel(modelObject *SchemaObject) (schema *jsonschema.Schema)
 				// Component names should match "^[a-zA-Z0-9\.\-_]+$"
 				// See https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#componentsObject
 				propertyName := strings.Replace(modelField.Name, "{name}", "^[a-zA-Z0-9\\\\.\\\\-_]+$", -1)
+				// Replace human-friendly (and regex-confusing) description with a blank pattern
+				propertyName = strings.Replace(propertyName, "{expression}", "^", -1)
+				propertyName = strings.Replace(propertyName, "{property}", "^", -1)
 				namedSchema := &jsonschema.NamedSchema{Name: propertyName, Value: schemaField}
 				newNamedSchemas = append(newNamedSchemas, namedSchema)
 			}

--- a/OpenAPIv3/schema-generator/main.go
+++ b/OpenAPIv3/schema-generator/main.go
@@ -782,7 +782,7 @@ func main() {
 	contentObject := schema.DefinitionWithName("content")
 	pairs := make([]*jsonschema.NamedSchema, 0)
 	contentObject.PatternProperties = &pairs
-	namedSchema := &jsonschema.NamedSchema{Name: "{media-type}", Value: &jsonschema.Schema{Ref: stringptr("#/definitions/mediaType")}}
+	namedSchema := &jsonschema.NamedSchema{Name: "^", Value: &jsonschema.Schema{Ref: stringptr("#/definitions/mediaType")}}
 	*(contentObject.PatternProperties) = append(*(contentObject.PatternProperties), namedSchema)
 
 	// write the updated schema


### PR DESCRIPTION
[Based on the openapi-v3.0.0-rc2 branch]

Generated JSON Schema uses the following values as regex in patternProperties:
* `{name}`
* `{path}`
* `{media-type}`
* `{expression}`
* `{property}`

They are human-friendly and easy to understand, but unfortunately, JSON Schema validator does not treat it the same way as humans. 

## `{` and `}` in patternProperties
[In JSON Schema](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.17):
> Each property name of this ("patternProperties") object SHOULD be a valid regular expression, according to the ECMA 262 regular expression dialect.  

ECMA 262 does not allow using `{` and `}` as a PatternCharacters:
> PatternCharacter ::
SourceCharacter but not one of -
^ $ \ . * + ? ( ) [ ] { } |

and treats their combination as a [Quantifier](https://www.ecma-international.org/ecma-262/5.1/#sec-15.10.2.7) (range for matching the patterns).

Some JSON Schema validators fail on such values for pattern properties, others simply don't match elements as expected.

## Additional information regarding `{name}` and `{path}` in OpenAPI v3 specification
So, maybe we should escape`{` and `}` in pattern properties? Not really.
OpenAPI v3 specification provides some insights about what the component `{name}`s [should look like](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#componentsObject):
> Component names should match "^[a-zA-Z0-9\.\-_]+$"

And as for [`{path}`](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#paths-object):
> The field name MUST begin with a slash

JSON Schema for OpenAPI v2 [uses "^/"](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/schemas/v2.0/schema.json#L173) as regex for paths - I used the same regex for v3.

I used an "allow anything" (`^`) regex for remaining pattern properties (`{media-type}`, `{expression}`, and `{property}`).