### PR TITLE
Copy patternProperties from parameter to header object

### DIFF
--- a/OpenAPIv3/openapi-3.0.json
+++ b/OpenAPIv3/openapi-3.0.json
@@ -703,6 +703,11 @@
       "type": "object",
       "description": "The Header Object follows the structure of the Parameter Object, with the following changes:  1. `name` MUST NOT be specified, it is given in the Headers Object. 1. `in` MUST NOT be specified, it is implicitly in `header`. 1. All traits that are affected by the location MUST be applicable to a location of `header` (for example, `style`).",
       "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/specificationExtension"
+        }
+      },
       "properties": {
         "name": {
           "type": "string"

--- a/OpenAPIv3/schema-generator/main.go
+++ b/OpenAPIv3/schema-generator/main.go
@@ -639,6 +639,9 @@ func main() {
 		newArray := make([]*jsonschema.NamedSchema, 0)
 		newArray = append(newArray, *(parameterObject.Properties)...)
 		headerObject.Properties = &newArray
+		ppArray := make([]*jsonschema.NamedSchema, 0)
+		ppArray = append(ppArray, *(parameterObject.PatternProperties)...)
+		headerObject.PatternProperties = &ppArray
 		// we need to remove a few properties...
 	}
 


### PR DESCRIPTION
As the `header` object takes its structure from the `parameter` object, we must copy the `patternProperties` as well as the `properties`, i.e. we make it extendable with specification extensions.

Similar disclaimer to before; go novice.