### PR TITLE
Reduce the amount of memory and CPU used by generated by OpenAPI code

### DIFF
--- a/OpenAPIv2/OpenAPIv2.go
+++ b/OpenAPIv2/OpenAPIv2.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"github.com/googleapis/gnostic/compiler"
 	"gopkg.in/yaml.v2"
+	"regexp"
 	"strings"
 )
 
@@ -84,7 +85,7 @@ func NewApiKeySecurity(in interface{}, context *compiler.Context) (*ApiKeySecuri
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"description", "in", "name", "type"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -145,7 +146,7 @@ func NewApiKeySecurity(in interface{}, context *compiler.Context) (*ApiKeySecuri
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -189,7 +190,7 @@ func NewBasicAuthenticationSecurity(in interface{}, context *compiler.Context) (
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"description", "type"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -226,7 +227,7 @@ func NewBasicAuthenticationSecurity(in interface{}, context *compiler.Context) (
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -270,7 +271,7 @@ func NewBodyParameter(in interface{}, context *compiler.Context) (*BodyParameter
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"description", "in", "name", "required", "schema"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -334,7 +335,7 @@ func NewBodyParameter(in interface{}, context *compiler.Context) (*BodyParameter
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -372,7 +373,7 @@ func NewContact(in interface{}, context *compiler.Context) (*Contact, error) {
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"email", "name", "url"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -412,7 +413,7 @@ func NewContact(in interface{}, context *compiler.Context) (*Contact, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -528,7 +529,7 @@ func NewDocument(in interface{}, context *compiler.Context) (*Document, error) {
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"basePath", "consumes", "definitions", "externalDocs", "host", "info", "parameters", "paths", "produces", "responses", "schemes", "security", "securityDefinitions", "swagger", "tags"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -708,7 +709,7 @@ func NewDocument(in interface{}, context *compiler.Context) (*Document, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -794,7 +795,7 @@ func NewExternalDocs(in interface{}, context *compiler.Context) (*ExternalDocs, 
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"description", "url"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -825,7 +826,7 @@ func NewExternalDocs(in interface{}, context *compiler.Context) (*ExternalDocs, 
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -869,7 +870,7 @@ func NewFileSchema(in interface{}, context *compiler.Context) (*FileSchema, erro
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"default", "description", "example", "externalDocs", "format", "readOnly", "required", "title", "type"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -971,7 +972,7 @@ func NewFileSchema(in interface{}, context *compiler.Context) (*FileSchema, erro
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -1009,7 +1010,7 @@ func NewFormDataParameterSubSchema(in interface{}, context *compiler.Context) (*
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"allowEmptyValue", "collectionFormat", "default", "description", "enum", "exclusiveMaximum", "exclusiveMinimum", "format", "in", "items", "maxItems", "maxLength", "maximum", "minItems", "minLength", "minimum", "multipleOf", "name", "pattern", "required", "type", "uniqueItems"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -1295,7 +1296,7 @@ func NewFormDataParameterSubSchema(in interface{}, context *compiler.Context) (*
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -1339,7 +1340,7 @@ func NewHeader(in interface{}, context *compiler.Context) (*Header, error) {
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"collectionFormat", "default", "description", "enum", "exclusiveMaximum", "exclusiveMinimum", "format", "items", "maxItems", "maxLength", "maximum", "minItems", "minLength", "minimum", "multipleOf", "pattern", "type", "uniqueItems"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -1583,7 +1584,7 @@ func NewHeader(in interface{}, context *compiler.Context) (*Header, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -1621,7 +1622,7 @@ func NewHeaderParameterSubSchema(in interface{}, context *compiler.Context) (*He
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"collectionFormat", "default", "description", "enum", "exclusiveMaximum", "exclusiveMinimum", "format", "in", "items", "maxItems", "maxLength", "maximum", "minItems", "minLength", "minimum", "multipleOf", "name", "pattern", "required", "type", "uniqueItems"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -1898,7 +1899,7 @@ func NewHeaderParameterSubSchema(in interface{}, context *compiler.Context) (*He
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -1972,7 +1973,7 @@ func NewInfo(in interface{}, context *compiler.Context) (*Info, error) {
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"contact", "description", "license", "termsOfService", "title", "version"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2039,7 +2040,7 @@ func NewInfo(in interface{}, context *compiler.Context) (*Info, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -2102,7 +2103,7 @@ func NewJsonReference(in interface{}, context *compiler.Context) (*JsonReference
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"$ref", "description"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2146,7 +2147,7 @@ func NewLicense(in interface{}, context *compiler.Context) (*License, error) {
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"name", "url"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2177,7 +2178,7 @@ func NewLicense(in interface{}, context *compiler.Context) (*License, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -2215,7 +2216,7 @@ func NewNamedAny(in interface{}, context *compiler.Context) (*NamedAny, error) {
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2253,7 +2254,7 @@ func NewNamedHeader(in interface{}, context *compiler.Context) (*NamedHeader, er
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2291,7 +2292,7 @@ func NewNamedParameter(in interface{}, context *compiler.Context) (*NamedParamet
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2329,7 +2330,7 @@ func NewNamedPathItem(in interface{}, context *compiler.Context) (*NamedPathItem
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2367,7 +2368,7 @@ func NewNamedResponse(in interface{}, context *compiler.Context) (*NamedResponse
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2405,7 +2406,7 @@ func NewNamedResponseValue(in interface{}, context *compiler.Context) (*NamedRes
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2443,7 +2444,7 @@ func NewNamedSchema(in interface{}, context *compiler.Context) (*NamedSchema, er
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2481,7 +2482,7 @@ func NewNamedSecurityDefinitionsItem(in interface{}, context *compiler.Context) 
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2519,7 +2520,7 @@ func NewNamedString(in interface{}, context *compiler.Context) (*NamedString, er
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2557,7 +2558,7 @@ func NewNamedStringArray(in interface{}, context *compiler.Context) (*NamedStrin
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2669,7 +2670,7 @@ func NewOauth2AccessCodeSecurity(in interface{}, context *compiler.Context) (*Oa
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"authorizationUrl", "description", "flow", "scopes", "tokenUrl", "type"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2748,7 +2749,7 @@ func NewOauth2AccessCodeSecurity(in interface{}, context *compiler.Context) (*Oa
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -2792,7 +2793,7 @@ func NewOauth2ApplicationSecurity(in interface{}, context *compiler.Context) (*O
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"description", "flow", "scopes", "tokenUrl", "type"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2862,7 +2863,7 @@ func NewOauth2ApplicationSecurity(in interface{}, context *compiler.Context) (*O
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -2906,7 +2907,7 @@ func NewOauth2ImplicitSecurity(in interface{}, context *compiler.Context) (*Oaut
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"authorizationUrl", "description", "flow", "scopes", "type"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2976,7 +2977,7 @@ func NewOauth2ImplicitSecurity(in interface{}, context *compiler.Context) (*Oaut
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -3020,7 +3021,7 @@ func NewOauth2PasswordSecurity(in interface{}, context *compiler.Context) (*Oaut
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"description", "flow", "scopes", "tokenUrl", "type"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -3090,7 +3091,7 @@ func NewOauth2PasswordSecurity(in interface{}, context *compiler.Context) (*Oaut
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -3160,7 +3161,7 @@ func NewOperation(in interface{}, context *compiler.Context) (*Operation, error)
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"consumes", "deprecated", "description", "externalDocs", "operationId", "parameters", "produces", "responses", "schemes", "security", "summary", "tags"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -3309,7 +3310,7 @@ func NewOperation(in interface{}, context *compiler.Context) (*Operation, error)
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -3457,7 +3458,7 @@ func NewPathItem(in interface{}, context *compiler.Context) (*PathItem, error) {
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"$ref", "delete", "get", "head", "options", "parameters", "patch", "post", "put"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -3558,7 +3559,7 @@ func NewPathItem(in interface{}, context *compiler.Context) (*PathItem, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -3602,7 +3603,7 @@ func NewPathParameterSubSchema(in interface{}, context *compiler.Context) (*Path
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"collectionFormat", "default", "description", "enum", "exclusiveMaximum", "exclusiveMinimum", "format", "in", "items", "maxItems", "maxLength", "maximum", "minItems", "minLength", "minimum", "multipleOf", "name", "pattern", "required", "type", "uniqueItems"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -3879,7 +3880,7 @@ func NewPathParameterSubSchema(in interface{}, context *compiler.Context) (*Path
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -3917,7 +3918,7 @@ func NewPaths(in interface{}, context *compiler.Context) (*Paths, error) {
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{}
-		allowedPatterns := []string{"^x-", "^/"}
+		allowedPatterns := []*regexp.Regexp{pattern0, pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -3930,7 +3931,7 @@ func NewPaths(in interface{}, context *compiler.Context) (*Paths, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -3961,7 +3962,7 @@ func NewPaths(in interface{}, context *compiler.Context) (*Paths, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^/", k) {
+				if strings.HasPrefix(k, "/") {
 					pair := &NamedPathItem{}
 					pair.Name = k
 					var err error
@@ -3987,7 +3988,7 @@ func NewPrimitivesItems(in interface{}, context *compiler.Context) (*PrimitivesI
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"collectionFormat", "default", "enum", "exclusiveMaximum", "exclusiveMinimum", "format", "items", "maxItems", "maxLength", "maximum", "minItems", "minLength", "minimum", "multipleOf", "pattern", "type", "uniqueItems"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -4222,7 +4223,7 @@ func NewPrimitivesItems(in interface{}, context *compiler.Context) (*PrimitivesI
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -4290,7 +4291,7 @@ func NewQueryParameterSubSchema(in interface{}, context *compiler.Context) (*Que
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"allowEmptyValue", "collectionFormat", "default", "description", "enum", "exclusiveMaximum", "exclusiveMinimum", "format", "in", "items", "maxItems", "maxLength", "maximum", "minItems", "minLength", "minimum", "multipleOf", "name", "pattern", "required", "type", "uniqueItems"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -4576,7 +4577,7 @@ func NewQueryParameterSubSchema(in interface{}, context *compiler.Context) (*Que
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -4620,7 +4621,7 @@ func NewResponse(in interface{}, context *compiler.Context) (*Response, error) {
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"description", "examples", "headers", "schema"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -4669,7 +4670,7 @@ func NewResponse(in interface{}, context *compiler.Context) (*Response, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -4777,7 +4778,7 @@ func NewResponses(in interface{}, context *compiler.Context) (*Responses, error)
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{}
-		allowedPatterns := []string{"^([0-9]{3})$|^(default)$", "^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern2, pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -4790,7 +4791,7 @@ func NewResponses(in interface{}, context *compiler.Context) (*Responses, error)
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^([0-9]{3})$|^(default)$", k) {
+				if pattern2.MatchString(k) {
 					pair := &NamedResponseValue{}
 					pair.Name = k
 					var err error
@@ -4809,7 +4810,7 @@ func NewResponses(in interface{}, context *compiler.Context) (*Responses, error)
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -4847,7 +4848,7 @@ func NewSchema(in interface{}, context *compiler.Context) (*Schema, error) {
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"$ref", "additionalProperties", "allOf", "default", "description", "discriminator", "enum", "example", "exclusiveMaximum", "exclusiveMinimum", "externalDocs", "format", "items", "maxItems", "maxLength", "maxProperties", "maximum", "minItems", "minLength", "minProperties", "minimum", "multipleOf", "pattern", "properties", "readOnly", "required", "title", "type", "uniqueItems", "xml"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -5200,7 +5201,7 @@ func NewSchema(in interface{}, context *compiler.Context) (*Schema, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -5457,7 +5458,7 @@ func NewTag(in interface{}, context *compiler.Context) (*Tag, error) {
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"description", "externalDocs", "name"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -5497,7 +5498,7 @@ func NewTag(in interface{}, context *compiler.Context) (*Tag, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -5603,7 +5604,7 @@ func NewXml(in interface{}, context *compiler.Context) (*Xml, error) {
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"attribute", "name", "namespace", "prefix", "wrapped"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -5661,7 +5662,7 @@ func NewXml(in interface{}, context *compiler.Context) (*Xml, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -8719,3 +8720,9 @@ func (m *Xml) ToRawInfo() interface{} {
 	// &{Name:VendorExtension Type:NamedAny StringEnumValues:[] MapType:Any Repeated:true Pattern:^x- Implicit:true Description:}
 	return info
 }
+
+var (
+	pattern0 = regexp.MustCompile("^x-")
+	pattern1 = regexp.MustCompile("^/")
+	pattern2 = regexp.MustCompile("^([0-9]{3})$|^(default)$")
+)

--- a/OpenAPIv3/OpenAPIv3.go
+++ b/OpenAPIv3/OpenAPIv3.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"github.com/googleapis/gnostic/compiler"
 	"gopkg.in/yaml.v2"
+	"regexp"
 	"strings"
 )
 
@@ -148,7 +149,7 @@ func NewCallback(in interface{}, context *compiler.Context) (*Callback, error) {
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{}
-		allowedPatterns := []string{"^", "^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern0, pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -161,7 +162,7 @@ func NewCallback(in interface{}, context *compiler.Context) (*Callback, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^", k) {
+				if true {
 					pair := &NamedPathItem{}
 					pair.Name = k
 					var err error
@@ -180,7 +181,7 @@ func NewCallback(in interface{}, context *compiler.Context) (*Callback, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -288,7 +289,7 @@ func NewComponents(in interface{}, context *compiler.Context) (*Components, erro
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"callbacks", "examples", "headers", "links", "parameters", "requestBodies", "responses", "schemas", "securitySchemes"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -382,7 +383,7 @@ func NewComponents(in interface{}, context *compiler.Context) (*Components, erro
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -420,7 +421,7 @@ func NewContact(in interface{}, context *compiler.Context) (*Contact, error) {
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"email", "name", "url"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -460,7 +461,7 @@ func NewContact(in interface{}, context *compiler.Context) (*Contact, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -539,7 +540,7 @@ func NewDiscriminator(in interface{}, context *compiler.Context) (*Discriminator
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"mapping", "propertyName"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -583,7 +584,7 @@ func NewDocument(in interface{}, context *compiler.Context) (*Document, error) {
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"components", "externalDocs", "info", "openapi", "paths", "security", "servers", "tags"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -689,7 +690,7 @@ func NewDocument(in interface{}, context *compiler.Context) (*Document, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -727,7 +728,7 @@ func NewEncoding(in interface{}, context *compiler.Context) (*Encoding, error) {
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"allowReserved", "contentType", "explode", "headers", "style"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -785,7 +786,7 @@ func NewEncoding(in interface{}, context *compiler.Context) (*Encoding, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -853,7 +854,7 @@ func NewExample(in interface{}, context *compiler.Context) (*Example, error) {
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"description", "externalValue", "summary", "value"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -902,7 +903,7 @@ func NewExample(in interface{}, context *compiler.Context) (*Example, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -980,7 +981,7 @@ func NewExamples(in interface{}, context *compiler.Context) (*Examples, error) {
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -1078,7 +1079,7 @@ func NewExternalDocs(in interface{}, context *compiler.Context) (*ExternalDocs, 
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"description", "url"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -1109,7 +1110,7 @@ func NewExternalDocs(in interface{}, context *compiler.Context) (*ExternalDocs, 
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -1147,7 +1148,7 @@ func NewHeader(in interface{}, context *compiler.Context) (*Header, error) {
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"allowEmptyValue", "allowReserved", "content", "deprecated", "description", "example", "examples", "explode", "required", "schema", "style"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -1259,7 +1260,7 @@ func NewHeader(in interface{}, context *compiler.Context) (*Header, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -1373,7 +1374,7 @@ func NewInfo(in interface{}, context *compiler.Context) (*Info, error) {
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"contact", "description", "license", "termsOfService", "title", "version"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -1440,7 +1441,7 @@ func NewInfo(in interface{}, context *compiler.Context) (*Info, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -1503,7 +1504,7 @@ func NewLicense(in interface{}, context *compiler.Context) (*License, error) {
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"name", "url"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -1534,7 +1535,7 @@ func NewLicense(in interface{}, context *compiler.Context) (*License, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -1572,7 +1573,7 @@ func NewLink(in interface{}, context *compiler.Context) (*Link, error) {
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"description", "operationId", "operationRef", "parameters", "requestBody", "server"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -1639,7 +1640,7 @@ func NewLink(in interface{}, context *compiler.Context) (*Link, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -1747,7 +1748,7 @@ func NewMediaType(in interface{}, context *compiler.Context) (*MediaType, error)
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"encoding", "example", "examples", "schema"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -1796,7 +1797,7 @@ func NewMediaType(in interface{}, context *compiler.Context) (*MediaType, error)
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -1864,7 +1865,7 @@ func NewNamedAny(in interface{}, context *compiler.Context) (*NamedAny, error) {
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -1902,7 +1903,7 @@ func NewNamedAnyOrExpression(in interface{}, context *compiler.Context) (*NamedA
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -1940,7 +1941,7 @@ func NewNamedCallbackOrReference(in interface{}, context *compiler.Context) (*Na
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -1978,7 +1979,7 @@ func NewNamedEncoding(in interface{}, context *compiler.Context) (*NamedEncoding
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2016,7 +2017,7 @@ func NewNamedExampleOrReference(in interface{}, context *compiler.Context) (*Nam
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2054,7 +2055,7 @@ func NewNamedHeaderOrReference(in interface{}, context *compiler.Context) (*Name
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2092,7 +2093,7 @@ func NewNamedLinkOrReference(in interface{}, context *compiler.Context) (*NamedL
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2130,7 +2131,7 @@ func NewNamedMediaType(in interface{}, context *compiler.Context) (*NamedMediaTy
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2168,7 +2169,7 @@ func NewNamedParameterOrReference(in interface{}, context *compiler.Context) (*N
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2206,7 +2207,7 @@ func NewNamedPathItem(in interface{}, context *compiler.Context) (*NamedPathItem
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2244,7 +2245,7 @@ func NewNamedRequestBodyOrReference(in interface{}, context *compiler.Context) (
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2282,7 +2283,7 @@ func NewNamedResponseOrReference(in interface{}, context *compiler.Context) (*Na
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2320,7 +2321,7 @@ func NewNamedSchemaOrReference(in interface{}, context *compiler.Context) (*Name
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2358,7 +2359,7 @@ func NewNamedSecuritySchemeOrReference(in interface{}, context *compiler.Context
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2396,7 +2397,7 @@ func NewNamedServerVariable(in interface{}, context *compiler.Context) (*NamedSe
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2434,7 +2435,7 @@ func NewNamedString(in interface{}, context *compiler.Context) (*NamedString, er
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"name", "value"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2472,7 +2473,7 @@ func NewOauthFlow(in interface{}, context *compiler.Context) (*OauthFlow, error)
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"authorizationUrl", "refreshUrl", "scopes", "tokenUrl"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2521,7 +2522,7 @@ func NewOauthFlow(in interface{}, context *compiler.Context) (*OauthFlow, error)
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -2559,7 +2560,7 @@ func NewOauthFlows(in interface{}, context *compiler.Context) (*OauthFlows, erro
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"authorizationCode", "clientCredentials", "implicit", "password"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2608,7 +2609,7 @@ func NewOauthFlows(in interface{}, context *compiler.Context) (*OauthFlows, erro
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -2694,7 +2695,7 @@ func NewOperation(in interface{}, context *compiler.Context) (*Operation, error)
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"callbacks", "deprecated", "description", "externalDocs", "operationId", "parameters", "requestBody", "responses", "security", "servers", "summary", "tags"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -2838,7 +2839,7 @@ func NewOperation(in interface{}, context *compiler.Context) (*Operation, error)
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -2882,7 +2883,7 @@ func NewParameter(in interface{}, context *compiler.Context) (*Parameter, error)
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"allowEmptyValue", "allowReserved", "content", "deprecated", "description", "example", "examples", "explode", "in", "name", "required", "schema", "style"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -3012,7 +3013,7 @@ func NewParameter(in interface{}, context *compiler.Context) (*Parameter, error)
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -3120,7 +3121,7 @@ func NewPathItem(in interface{}, context *compiler.Context) (*PathItem, error) {
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"$ref", "delete", "description", "get", "head", "options", "parameters", "patch", "post", "put", "servers", "summary", "trace"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -3264,7 +3265,7 @@ func NewPathItem(in interface{}, context *compiler.Context) (*PathItem, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -3302,7 +3303,7 @@ func NewPaths(in interface{}, context *compiler.Context) (*Paths, error) {
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{}
-		allowedPatterns := []string{"^/", "^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern2, pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -3315,7 +3316,7 @@ func NewPaths(in interface{}, context *compiler.Context) (*Paths, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^/", k) {
+				if strings.HasPrefix(k, "/") {
 					pair := &NamedPathItem{}
 					pair.Name = k
 					var err error
@@ -3334,7 +3335,7 @@ func NewPaths(in interface{}, context *compiler.Context) (*Paths, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -3408,7 +3409,7 @@ func NewReference(in interface{}, context *compiler.Context) (*Reference, error)
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"$ref"}
-		allowedPatterns := []string{}
+		var allowedPatterns []*regexp.Regexp
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -3473,7 +3474,7 @@ func NewRequestBody(in interface{}, context *compiler.Context) (*RequestBody, er
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"content", "description", "required"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -3513,7 +3514,7 @@ func NewRequestBody(in interface{}, context *compiler.Context) (*RequestBody, er
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -3597,7 +3598,7 @@ func NewResponse(in interface{}, context *compiler.Context) (*Response, error) {
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"content", "description", "headers", "links"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -3646,7 +3647,7 @@ func NewResponse(in interface{}, context *compiler.Context) (*Response, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -3724,7 +3725,7 @@ func NewResponses(in interface{}, context *compiler.Context) (*Responses, error)
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"default"}
-		allowedPatterns := []string{"^([0-9X]{3})$", "^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern3, pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -3746,7 +3747,7 @@ func NewResponses(in interface{}, context *compiler.Context) (*Responses, error)
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^([0-9X]{3})$", k) {
+				if pattern3.MatchString(k) {
 					pair := &NamedResponseOrReference{}
 					pair.Name = k
 					var err error
@@ -3765,7 +3766,7 @@ func NewResponses(in interface{}, context *compiler.Context) (*Responses, error)
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -3833,7 +3834,7 @@ func NewSchema(in interface{}, context *compiler.Context) (*Schema, error) {
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"additionalProperties", "allOf", "anyOf", "default", "deprecated", "description", "discriminator", "enum", "example", "exclusiveMaximum", "exclusiveMinimum", "externalDocs", "format", "items", "maxItems", "maxLength", "maxProperties", "maximum", "minItems", "minLength", "minProperties", "minimum", "multipleOf", "not", "nullable", "oneOf", "pattern", "properties", "readOnly", "required", "title", "type", "uniqueItems", "writeOnly", "xml"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -4245,7 +4246,7 @@ func NewSchema(in interface{}, context *compiler.Context) (*Schema, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -4353,7 +4354,7 @@ func NewSecurityRequirement(in interface{}, context *compiler.Context) (*Securit
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{}
-		allowedPatterns := []string{"^[a-zA-Z0-9\\.\\-_]+$"}
+		allowedPatterns := []*regexp.Regexp{pattern4}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -4379,7 +4380,7 @@ func NewSecurityScheme(in interface{}, context *compiler.Context) (*SecuritySche
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"bearerFormat", "description", "flows", "in", "name", "openIdConnectUrl", "scheme", "type"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -4464,7 +4465,7 @@ func NewSecurityScheme(in interface{}, context *compiler.Context) (*SecuritySche
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -4578,7 +4579,7 @@ func NewServer(in interface{}, context *compiler.Context) (*Server, error) {
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"description", "url", "variables"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -4618,7 +4619,7 @@ func NewServer(in interface{}, context *compiler.Context) (*Server, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -4662,7 +4663,7 @@ func NewServerVariable(in interface{}, context *compiler.Context) (*ServerVariab
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"default", "description", "enum"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -4704,7 +4705,7 @@ func NewServerVariable(in interface{}, context *compiler.Context) (*ServerVariab
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -4856,7 +4857,7 @@ func NewTag(in interface{}, context *compiler.Context) (*Tag, error) {
 			errors = append(errors, compiler.NewError(context, message))
 		}
 		allowedKeys := []string{"description", "externalDocs", "name"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -4896,7 +4897,7 @@ func NewTag(in interface{}, context *compiler.Context) (*Tag, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -4934,7 +4935,7 @@ func NewXml(in interface{}, context *compiler.Context) (*Xml, error) {
 		errors = append(errors, compiler.NewError(context, message))
 	} else {
 		allowedKeys := []string{"attribute", "name", "namespace", "prefix", "wrapped"}
-		allowedPatterns := []string{"^x-"}
+		allowedPatterns := []*regexp.Regexp{pattern1}
 		invalidKeys := compiler.InvalidKeysInMap(m, allowedKeys, allowedPatterns)
 		if len(invalidKeys) > 0 {
 			message := fmt.Sprintf("has invalid %s: %+v", compiler.PluralProperties(len(invalidKeys)), strings.Join(invalidKeys, ", "))
@@ -4992,7 +4993,7 @@ func NewXml(in interface{}, context *compiler.Context) (*Xml, error) {
 			k, ok := compiler.StringValue(item.Key)
 			if ok {
 				v := item.Value
-				if compiler.PatternMatches("^x-", k) {
+				if strings.HasPrefix(k, "x-") {
 					pair := &NamedAny{}
 					pair.Name = k
 					result := &Any{}
@@ -8322,3 +8323,11 @@ func (m *Xml) ToRawInfo() interface{} {
 	// &{Name:SpecificationExtension Type:NamedAny StringEnumValues:[] MapType:Any Repeated:true Pattern:^x- Implicit:true Description:}
 	return info
 }
+
+var (
+	pattern0 = regexp.MustCompile("^")
+	pattern1 = regexp.MustCompile("^x-")
+	pattern2 = regexp.MustCompile("^/")
+	pattern3 = regexp.MustCompile("^([0-9X]{3})$")
+	pattern4 = regexp.MustCompile("^[a-zA-Z0-9\\.\\-_]+$")
+)

--- a/generate-gnostic/generate-extension.go
+++ b/generate-gnostic/generate-extension.go
@@ -260,6 +260,7 @@ func GenerateExtension(schemaFile string, outDir string) error {
 	// generate the compiler
 	compiler := cc.GenerateCompiler(goPackageName, License, []string{
 		"fmt",
+		"regexp",
 		"strings",
 		"github.com/googleapis/gnostic/compiler",
 		"gopkg.in/yaml.v2",

--- a/generate-gnostic/main.go
+++ b/generate-gnostic/main.go
@@ -177,6 +177,7 @@ func generateOpenAPIModel(version string) error {
 		"fmt",
 		"gopkg.in/yaml.v2",
 		"strings",
+		"regexp",
 		"github.com/googleapis/gnostic/compiler",
 	})
 	goFileName := projectRoot + filename + "/" + filename + ".go"


### PR DESCRIPTION
The majority of uses of regex inside of the generated code suffer from easy to fix problems:

1. Use of uncompiled patterns - there are no patterns that aren't known ahead of time
2. Use of regex for trivial string operations.

This PR fixes kubernetes/kubernetes#49776 by removing the impact of the two issues above at
generation time.

In production systems using the generated code (Kubernetes and OpenShift) we measured that 1/3rd of all startup allocations and the majority of startup time was being consumed by this code (which is being used to parse and display OpenAPI models).  After this fix, allocations from this package drop to effectively zero.