### PR TITLE
JSON Schema for OAS3: Validate Contact#url and Contact#email

### DIFF
--- a/OpenAPIv3/schema-generator/main.go
+++ b/OpenAPIv3/schema-generator/main.go
@@ -642,7 +642,7 @@ func main() {
 
 	// manually set a few fields
 	schema.Title = stringptr("A JSON Schema for OpenAPI 3.0.")
-	schema.ID = stringptr("http://openapis.org/v3/schema.json#")
+	schema.Id = stringptr("http://openapis.org/v3/schema.json#")
 	schema.Schema = stringptr("http://json-schema.org/draft-04/schema#")
 
 	// loop over all models and create the corresponding schema objects
@@ -835,6 +835,19 @@ func main() {
 		contentObject.PatternProperties = &pairs
 		namedSchema := &jsonschema.NamedSchema{Name: "^", Value: &jsonschema.Schema{Ref: stringptr("#/definitions/mediaType")}}
 		*(contentObject.PatternProperties) = append(*(contentObject.PatternProperties), namedSchema)
+	}
+
+	// fix the contact object
+	contactObject := schema.DefinitionWithName("contact")
+	if contactObject != nil {
+		emailProperty := contactObject.PropertyWithName("email")
+		if emailProperty != nil {
+			emailProperty.Format = stringptr("email");
+		}
+		urlProperty := contactObject.PropertyWithName("url")
+		if urlProperty != nil {
+			urlProperty.Format = stringptr("uri");
+		}
 	}
 
 	// write the updated schema


### PR DESCRIPTION
See https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.0.md#contact-object

> The email address of the contact person/organization. MUST be in the format of an email address.

Added a `"format": "email"`. Similar approach is used in [JSON Schema for Swagger v2](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/schemas/v2.0/schema.json#L142)

> The URL pointing to the contact information. MUST be in the format of a URL.

JSON Schema Draft 4 does not have a string format for URL (see [Proposal: add format "url"](https://github.com/json-schema-org/json-schema-spec/issues/233)). The best approximation is `"format": "uri"` which is also used in JSON Schema for [Swagger v2](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/schemas/v2.0/schema.json#L137)