### PR TITLE
Init a surface if a plugin runs as standalone program

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# IntelliJ IDEA
+.idea
 # Eclipse
 .checkstyle
 .project
@@ -12,3 +14,5 @@ Packages
 .DS_Store
 *~
 Package.resolved
+# Sample files
+extensions/sample/generated

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can get protoc [here](https://github.com/google/protobuf).
 5. Run **gnostic**. This will create a file in the current directory named "petstore.pb" that contains a binary
 Protocol Buffer description of a sample API.
 
-        gnostic --pb-out=. examples/petstore.json
+        gnostic --pb-out=. examples/v2.0/json/petstore.json
 
 6. You can also compile files that you specify with a URL. Here's another way to compile the previous 
 example. This time we're creating "petstore.text", which contains a textual representation of the
@@ -92,7 +92,7 @@ that reports some basic information about an API. The "-" causes the plugin to
 write its output to stdout.
 
         go install github.com/googleapis/gnostic/plugins/gnostic-go-sample
-        gnostic examples/petstore.json --go-sample-out=-
+        gnostic examples/v2.0/json/petstore.json --go-sample-out=-
 
 ## Copyright
 

--- a/plugins/environment.go
+++ b/plugins/environment.go
@@ -13,6 +13,7 @@ import (
 
 	openapiv2 "github.com/googleapis/gnostic/OpenAPIv2"
 	openapiv3 "github.com/googleapis/gnostic/OpenAPIv3"
+	surface "github.com/googleapis/gnostic/surface"
 )
 
 // Environment contains the environment of a plugin call.
@@ -99,17 +100,17 @@ When the -plugin option is specified, these flags are ignored.`)
 		err = proto.Unmarshal(apiData, documentv2)
 		if err == nil {
 			env.Request.Openapi2 = documentv2
+			env.Request.Surface, err = surface.NewModelFromOpenAPI2(documentv2)
 		} else {
-			// ignore deserialization errors
-		}
-
-		// Then try to unmarshal OpenAPI v3.
-		documentv3 := &openapiv3.Document{}
-		err = proto.Unmarshal(apiData, documentv3)
-		if err == nil {
-			env.Request.Openapi3 = documentv3
-		} else {
-			// ignore deserialization errors
+			// ignore deserialization errors and try to unmarshal OpenAPI v3.
+			documentv3 := &openapiv3.Document{}
+			err = proto.Unmarshal(apiData, documentv3)
+			if err == nil {
+				env.Request.Openapi3 = documentv3
+				env.Request.Surface, err = surface.NewModelFromOpenAPI3(documentv3)
+			} else {
+				// ignore deserialization errors
+			}
 		}
 
 	}

--- a/plugins/gnostic-go-generator/render_client.go
+++ b/plugins/gnostic-go-generator/render_client.go
@@ -109,7 +109,9 @@ func (renderer *Renderer) RenderClient() ([]byte, error) {
 
 		if method.Method == "POST" {
 			f.WriteLine(`body := new(bytes.Buffer)`)
-			f.WriteLine(`json.NewEncoder(body).Encode(` + parametersType.FieldWithPosition(surface.Position_BODY).Name + `)`)
+			if parametersType != nil {
+				f.WriteLine(`json.NewEncoder(body).Encode(` + parametersType.FieldWithPosition(surface.Position_BODY).Name + `)`)
+			}
 			f.WriteLine(`req, err := http.NewRequest("` + method.Method + `", path, body)`)
 			f.WriteLine(`reqHeaders := make(http.Header)`)
 			f.WriteLine(`reqHeaders.Set("Content-Type", "application/json")`)


### PR DESCRIPTION
If we try to run a plugin as standalone program it will print the error and stops the execution. It happens because the model is not initialised.  

I added the initialization, moved the second condition inside else block to hold last error and added intelliJ IDEA project files to gitignore.