### PR TITLE
Ignore generated extension files and IntelliJ IDEA project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# IntelliJ IDEA
+.idea
 # Eclipse
 .checkstyle
 .project
@@ -12,3 +14,4 @@ Packages
 .DS_Store
 *~
 Package.resolved
+extensions/sample/generated


### PR DESCRIPTION
1. Adds IntelliJ project files to .gitignore. It is usefull for new Goglang IDE.
2. Ignores generated files of the extension sample. If we run 'make' it creates a folder 'extensions/sample/generated' with generated files. It should not be tracked by git.