### PR TITLE
Initialize request surface if a plugin runs as standalone program

### DIFF
--- a/plugins/environment.go
+++ b/plugins/environment.go
@@ -13,6 +13,7 @@ import (
 
 	openapiv2 "github.com/googleapis/gnostic/OpenAPIv2"
 	openapiv3 "github.com/googleapis/gnostic/OpenAPIv3"
+	surface "github.com/googleapis/gnostic/surface"
 )
 
 // Environment contains the environment of a plugin call.
@@ -99,17 +100,17 @@ When the -plugin option is specified, these flags are ignored.`)
 		err = proto.Unmarshal(apiData, documentv2)
 		if err == nil {
 			env.Request.Openapi2 = documentv2
+			env.Request.Surface, err = surface.NewModelFromOpenAPI2(documentv2)
 		} else {
-			// ignore deserialization errors
-		}
-
-		// Then try to unmarshal OpenAPI v3.
-		documentv3 := &openapiv3.Document{}
-		err = proto.Unmarshal(apiData, documentv3)
-		if err == nil {
-			env.Request.Openapi3 = documentv3
-		} else {
-			// ignore deserialization errors
+			// ignore deserialization errors and try to unmarshal OpenAPI v3.
+			documentv3 := &openapiv3.Document{}
+			err = proto.Unmarshal(apiData, documentv3)
+			if err == nil {
+				env.Request.Openapi3 = documentv3
+				env.Request.Surface, err = surface.NewModelFromOpenAPI3(documentv3)
+			} else {
+				// ignore deserialization errors
+			}
 		}
 
 	}


### PR DESCRIPTION
If we try to run a plugin as standalone program it will print the error and stops the execution. It happens because the model is not initialized.

How to reproduce:
Generate protocol buffer binary file with gnostic from any OpenAPI(Swagger) file and run gnostic-go-generator plugin from command line.

Also an attempt to deserialize OpenAPIv3 should not be done as independent. It may set incorrect value to the 'err' variable and return unexpected error.