### PR TITLE
Fix wrong file paths in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can get protoc [here](https://github.com/google/protobuf).
 5. Run **gnostic**. This will create a file in the current directory named "petstore.pb" that contains a binary
 Protocol Buffer description of a sample API.
 
-        gnostic --pb-out=. examples/petstore.json
+        gnostic --pb-out=. examples/v2.0/json/petstore.json
 
 6. You can also compile files that you specify with a URL. Here's another way to compile the previous 
 example. This time we're creating "petstore.text", which contains a textual representation of the
@@ -92,7 +92,7 @@ that reports some basic information about an API. The "-" causes the plugin to
 write its output to stdout.
 
         go install github.com/googleapis/gnostic/plugins/gnostic-go-sample
-        gnostic examples/petstore.json --go-sample-out=-
+        gnostic examples/v2.0/json/petstore.json --go-sample-out=-
 
 ## Copyright
 


### PR DESCRIPTION
Paths to OpenAPI examples are incorrect.