### PR TITLE
 Fix null pointer exception if POST method has not body params

### DIFF
--- a/plugins/gnostic-go-generator/render_client.go
+++ b/plugins/gnostic-go-generator/render_client.go
@@ -109,7 +109,9 @@ func (renderer *Renderer) RenderClient() ([]byte, error) {
 
 		if method.Method == "POST" {
 			f.WriteLine(`body := new(bytes.Buffer)`)
-			f.WriteLine(`json.NewEncoder(body).Encode(` + parametersType.FieldWithPosition(surface.Position_BODY).Name + `)`)
+			if parametersType != nil {
+				f.WriteLine(`json.NewEncoder(body).Encode(` + parametersType.FieldWithPosition(surface.Position_BODY).Name + `)`)
+			}
 			f.WriteLine(`req, err := http.NewRequest("` + method.Method + `", path, body)`)
 			f.WriteLine(`reqHeaders := make(http.Header)`)
 			f.WriteLine(`reqHeaders.Set("Content-Type", "application/json")`)


### PR DESCRIPTION
There is a bug in gnostic-go-generator plugin. If request method is POST and body has not parameters it throws the error: 

> panic: runtime error: invalid memory address or nil pointer dereference
> [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1268347]

How to reproduce:

`gnostic --go-client-out=outdir examples/v2.0/json/petstore.json`