### PR TITLE
Add imported generated packages so that `go get` with `...` can succeed

### DIFF
--- a/plugins/gnostic-go-generator/examples/v2.0/apis_guru/main.go
+++ b/plugins/gnostic-go-generator/examples/v2.0/apis_guru/main.go
@@ -1,9 +1,13 @@
+// +build ignore
+// This file is omitted when getting with `go get github.com/googleapis/gnostic/...`
+
 package main
 
 import (
 	"fmt"
-        "github.com/googleapis/gnostic/plugins/gnostic-go-generator/examples/v2.0/apis_guru/apis_guru"
 	"sort"
+
+	"github.com/googleapis/gnostic/plugins/gnostic-go-generator/examples/v2.0/apis_guru/apis_guru"
 )
 
 func main() {

--- a/plugins/gnostic-go-generator/examples/v2.0/bookstore/bookstore/bookstore.go
+++ b/plugins/gnostic-go-generator/examples/v2.0/bookstore/bookstore/bookstore.go
@@ -1,0 +1,19 @@
+/*
+ Copyright 2017 Google Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+// Package bookstore exists to allow this repo to work with recursive go get.
+// It will be filled in with auto generated code.
+package bookstore

--- a/plugins/gnostic-go-generator/examples/v2.0/sample/sample/sample.go
+++ b/plugins/gnostic-go-generator/examples/v2.0/sample/sample/sample.go
@@ -1,0 +1,19 @@
+/*
+ Copyright 2017 Google Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+// Package sample exists to allow this repo to work with recursive go get.
+// It will be filled in with auto generated code.
+package sample

--- a/plugins/gnostic-go-generator/examples/v2.0/xkcd/main.go
+++ b/plugins/gnostic-go-generator/examples/v2.0/xkcd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/googleapis/gnostic/plugins/gnostic-go-generator/examples/v2.0/xkcd/xkcd"
 )
 

--- a/plugins/gnostic-go-generator/examples/v2.0/xkcd/xkcd/xkcd.go
+++ b/plugins/gnostic-go-generator/examples/v2.0/xkcd/xkcd/xkcd.go
@@ -1,0 +1,19 @@
+/*
+ Copyright 2017 Google Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+// Package xkcd exists to allow this repo to work with recursive go get.
+// It will be filled in with auto generated code.
+package xkcd

--- a/plugins/gnostic-go-generator/examples/v3.0/bookstore/bookstore/bookstore.go
+++ b/plugins/gnostic-go-generator/examples/v3.0/bookstore/bookstore/bookstore.go
@@ -1,0 +1,19 @@
+/*
+ Copyright 2017 Google Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+// Package bookstore exists to allow this repo to work with recursive go get.
+// It will be filled in with auto generated code.
+package bookstore

--- a/plugins/gnostic-go-generator/examples/v3.0/urlshortener/urlshortener/urlshortener.go
+++ b/plugins/gnostic-go-generator/examples/v3.0/urlshortener/urlshortener/urlshortener.go
@@ -1,0 +1,19 @@
+/*
+ Copyright 2017 Google Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+// Package urlshortener exists to allow this repo to work with recursive go get.
+// It will be filled in with auto generated code.
+package urlshortener


### PR DESCRIPTION
Trying to recursively `go get` gnostic was failing, e.g.:
```go get -v -d github.com/googleapis/gnostic/plugins/...```
because these example Go files assume you have followed along with
the READMEs (or run the Makefile) and generated the libs the
examples depend on.

First I tried using `// +build ignore` signals to `go get` and `go build` that
they shouldn't evaluate these files, which did fix `go get` but broke
anything that tried to actually build these files (e.g. makefiles) and
broke the build.

Instead I have added placeholder packages for all of the packages that
will be generated but are not present, which allows `go get` to succeed,
e.g.:

```
googleapis$ go get -d -v ./gnostic/...
```

Fixes #87