### PR TITLE
Modify generated ToRawInfo methods to always include required fields.

### DIFF
--- a/OpenAPIv2/OpenAPIv2.go
+++ b/OpenAPIv2/OpenAPIv2.go
@@ -7105,15 +7105,15 @@ func (m *Any) ToRawInfo() interface{} {
 // ToRawInfo returns a description of ApiKeySecurity suitable for JSON or YAML export.
 func (m *ApiKeySecurity) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
-	if m.Type != "" {
-		info = append(info, yaml.MapItem{Key: "type", Value: m.Type})
+	if m == nil {
+		return info
 	}
-	if m.Name != "" {
-		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
-	}
-	if m.In != "" {
-		info = append(info, yaml.MapItem{Key: "in", Value: m.In})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "type", Value: m.Type})
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "in", Value: m.In})
 	if m.Description != "" {
 		info = append(info, yaml.MapItem{Key: "description", Value: m.Description})
 	}
@@ -7129,9 +7129,11 @@ func (m *ApiKeySecurity) ToRawInfo() interface{} {
 // ToRawInfo returns a description of BasicAuthenticationSecurity suitable for JSON or YAML export.
 func (m *BasicAuthenticationSecurity) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
-	if m.Type != "" {
-		info = append(info, yaml.MapItem{Key: "type", Value: m.Type})
+	if m == nil {
+		return info
 	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "type", Value: m.Type})
 	if m.Description != "" {
 		info = append(info, yaml.MapItem{Key: "description", Value: m.Description})
 	}
@@ -7147,21 +7149,21 @@ func (m *BasicAuthenticationSecurity) ToRawInfo() interface{} {
 // ToRawInfo returns a description of BodyParameter suitable for JSON or YAML export.
 func (m *BodyParameter) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Description != "" {
 		info = append(info, yaml.MapItem{Key: "description", Value: m.Description})
 	}
-	if m.Name != "" {
-		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
-	}
-	if m.In != "" {
-		info = append(info, yaml.MapItem{Key: "in", Value: m.In})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "in", Value: m.In})
 	if m.Required != false {
 		info = append(info, yaml.MapItem{Key: "required", Value: m.Required})
 	}
-	if m.Schema != nil {
-		info = append(info, yaml.MapItem{Key: "schema", Value: m.Schema.ToRawInfo()})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "schema", Value: m.Schema.ToRawInfo()})
 	// &{Name:schema Type:Schema StringEnumValues:[] MapType: Repeated:false Pattern: Implicit:false Description:}
 	if m.VendorExtension != nil {
 		for _, item := range m.VendorExtension {
@@ -7175,6 +7177,9 @@ func (m *BodyParameter) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Contact suitable for JSON or YAML export.
 func (m *Contact) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7196,6 +7201,9 @@ func (m *Contact) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Default suitable for JSON or YAML export.
 func (m *Default) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -7208,6 +7216,9 @@ func (m *Default) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Definitions suitable for JSON or YAML export.
 func (m *Definitions) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -7220,12 +7231,13 @@ func (m *Definitions) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Document suitable for JSON or YAML export.
 func (m *Document) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
-	if m.Swagger != "" {
-		info = append(info, yaml.MapItem{Key: "swagger", Value: m.Swagger})
+	if m == nil {
+		return info
 	}
-	if m.Info != nil {
-		info = append(info, yaml.MapItem{Key: "info", Value: m.Info.ToRawInfo()})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "swagger", Value: m.Swagger})
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "info", Value: m.Info.ToRawInfo()})
 	// &{Name:info Type:Info StringEnumValues:[] MapType: Repeated:false Pattern: Implicit:false Description:}
 	if m.Host != "" {
 		info = append(info, yaml.MapItem{Key: "host", Value: m.Host})
@@ -7242,9 +7254,8 @@ func (m *Document) ToRawInfo() interface{} {
 	if len(m.Produces) != 0 {
 		info = append(info, yaml.MapItem{Key: "produces", Value: m.Produces})
 	}
-	if m.Paths != nil {
-		info = append(info, yaml.MapItem{Key: "paths", Value: m.Paths.ToRawInfo()})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "paths", Value: m.Paths.ToRawInfo()})
 	// &{Name:paths Type:Paths StringEnumValues:[] MapType: Repeated:false Pattern: Implicit:false Description:}
 	if m.Definitions != nil {
 		info = append(info, yaml.MapItem{Key: "definitions", Value: m.Definitions.ToRawInfo()})
@@ -7294,6 +7305,9 @@ func (m *Document) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Examples suitable for JSON or YAML export.
 func (m *Examples) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -7306,12 +7320,14 @@ func (m *Examples) ToRawInfo() interface{} {
 // ToRawInfo returns a description of ExternalDocs suitable for JSON or YAML export.
 func (m *ExternalDocs) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Description != "" {
 		info = append(info, yaml.MapItem{Key: "description", Value: m.Description})
 	}
-	if m.Url != "" {
-		info = append(info, yaml.MapItem{Key: "url", Value: m.Url})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "url", Value: m.Url})
 	if m.VendorExtension != nil {
 		for _, item := range m.VendorExtension {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -7324,6 +7340,9 @@ func (m *ExternalDocs) ToRawInfo() interface{} {
 // ToRawInfo returns a description of FileSchema suitable for JSON or YAML export.
 func (m *FileSchema) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Format != "" {
 		info = append(info, yaml.MapItem{Key: "format", Value: m.Format})
 	}
@@ -7340,9 +7359,8 @@ func (m *FileSchema) ToRawInfo() interface{} {
 	if len(m.Required) != 0 {
 		info = append(info, yaml.MapItem{Key: "required", Value: m.Required})
 	}
-	if m.Type != "" {
-		info = append(info, yaml.MapItem{Key: "type", Value: m.Type})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "type", Value: m.Type})
 	if m.ReadOnly != false {
 		info = append(info, yaml.MapItem{Key: "readOnly", Value: m.ReadOnly})
 	}
@@ -7366,6 +7384,9 @@ func (m *FileSchema) ToRawInfo() interface{} {
 // ToRawInfo returns a description of FormDataParameterSubSchema suitable for JSON or YAML export.
 func (m *FormDataParameterSubSchema) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Required != false {
 		info = append(info, yaml.MapItem{Key: "required", Value: m.Required})
 	}
@@ -7451,9 +7472,11 @@ func (m *FormDataParameterSubSchema) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Header suitable for JSON or YAML export.
 func (m *Header) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
-	if m.Type != "" {
-		info = append(info, yaml.MapItem{Key: "type", Value: m.Type})
+	if m == nil {
+		return info
 	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "type", Value: m.Type})
 	if m.Format != "" {
 		info = append(info, yaml.MapItem{Key: "format", Value: m.Format})
 	}
@@ -7524,6 +7547,9 @@ func (m *Header) ToRawInfo() interface{} {
 // ToRawInfo returns a description of HeaderParameterSubSchema suitable for JSON or YAML export.
 func (m *HeaderParameterSubSchema) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Required != false {
 		info = append(info, yaml.MapItem{Key: "required", Value: m.Required})
 	}
@@ -7606,6 +7632,9 @@ func (m *HeaderParameterSubSchema) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Headers suitable for JSON or YAML export.
 func (m *Headers) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -7618,12 +7647,13 @@ func (m *Headers) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Info suitable for JSON or YAML export.
 func (m *Info) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
-	if m.Title != "" {
-		info = append(info, yaml.MapItem{Key: "title", Value: m.Title})
+	if m == nil {
+		return info
 	}
-	if m.Version != "" {
-		info = append(info, yaml.MapItem{Key: "version", Value: m.Version})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "title", Value: m.Title})
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "version", Value: m.Version})
 	if m.Description != "" {
 		info = append(info, yaml.MapItem{Key: "description", Value: m.Description})
 	}
@@ -7650,6 +7680,9 @@ func (m *Info) ToRawInfo() interface{} {
 // ToRawInfo returns a description of ItemsItem suitable for JSON or YAML export.
 func (m *ItemsItem) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if len(m.Schema) != 0 {
 		items := make([]interface{}, 0)
 		for _, item := range m.Schema {
@@ -7664,9 +7697,11 @@ func (m *ItemsItem) ToRawInfo() interface{} {
 // ToRawInfo returns a description of JsonReference suitable for JSON or YAML export.
 func (m *JsonReference) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
-	if m.XRef != "" {
-		info = append(info, yaml.MapItem{Key: "$ref", Value: m.XRef})
+	if m == nil {
+		return info
 	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "$ref", Value: m.XRef})
 	if m.Description != "" {
 		info = append(info, yaml.MapItem{Key: "description", Value: m.Description})
 	}
@@ -7676,9 +7711,11 @@ func (m *JsonReference) ToRawInfo() interface{} {
 // ToRawInfo returns a description of License suitable for JSON or YAML export.
 func (m *License) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
-	if m.Name != "" {
-		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
+	if m == nil {
+		return info
 	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	if m.Url != "" {
 		info = append(info, yaml.MapItem{Key: "url", Value: m.Url})
 	}
@@ -7694,6 +7731,9 @@ func (m *License) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedAny suitable for JSON or YAML export.
 func (m *NamedAny) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7704,6 +7744,9 @@ func (m *NamedAny) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedHeader suitable for JSON or YAML export.
 func (m *NamedHeader) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7714,6 +7757,9 @@ func (m *NamedHeader) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedParameter suitable for JSON or YAML export.
 func (m *NamedParameter) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7724,6 +7770,9 @@ func (m *NamedParameter) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedPathItem suitable for JSON or YAML export.
 func (m *NamedPathItem) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7734,6 +7783,9 @@ func (m *NamedPathItem) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedResponse suitable for JSON or YAML export.
 func (m *NamedResponse) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7744,6 +7796,9 @@ func (m *NamedResponse) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedResponseValue suitable for JSON or YAML export.
 func (m *NamedResponseValue) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7754,6 +7809,9 @@ func (m *NamedResponseValue) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedSchema suitable for JSON or YAML export.
 func (m *NamedSchema) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7764,6 +7822,9 @@ func (m *NamedSchema) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedSecurityDefinitionsItem suitable for JSON or YAML export.
 func (m *NamedSecurityDefinitionsItem) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7774,6 +7835,9 @@ func (m *NamedSecurityDefinitionsItem) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedString suitable for JSON or YAML export.
 func (m *NamedString) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7786,6 +7850,9 @@ func (m *NamedString) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedStringArray suitable for JSON or YAML export.
 func (m *NamedStringArray) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7823,22 +7890,21 @@ func (m *NonBodyParameter) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Oauth2AccessCodeSecurity suitable for JSON or YAML export.
 func (m *Oauth2AccessCodeSecurity) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
-	if m.Type != "" {
-		info = append(info, yaml.MapItem{Key: "type", Value: m.Type})
+	if m == nil {
+		return info
 	}
-	if m.Flow != "" {
-		info = append(info, yaml.MapItem{Key: "flow", Value: m.Flow})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "type", Value: m.Type})
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "flow", Value: m.Flow})
 	if m.Scopes != nil {
 		info = append(info, yaml.MapItem{Key: "scopes", Value: m.Scopes.ToRawInfo()})
 	}
 	// &{Name:scopes Type:Oauth2Scopes StringEnumValues:[] MapType: Repeated:false Pattern: Implicit:false Description:}
-	if m.AuthorizationUrl != "" {
-		info = append(info, yaml.MapItem{Key: "authorizationUrl", Value: m.AuthorizationUrl})
-	}
-	if m.TokenUrl != "" {
-		info = append(info, yaml.MapItem{Key: "tokenUrl", Value: m.TokenUrl})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "authorizationUrl", Value: m.AuthorizationUrl})
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "tokenUrl", Value: m.TokenUrl})
 	if m.Description != "" {
 		info = append(info, yaml.MapItem{Key: "description", Value: m.Description})
 	}
@@ -7854,19 +7920,19 @@ func (m *Oauth2AccessCodeSecurity) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Oauth2ApplicationSecurity suitable for JSON or YAML export.
 func (m *Oauth2ApplicationSecurity) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
-	if m.Type != "" {
-		info = append(info, yaml.MapItem{Key: "type", Value: m.Type})
+	if m == nil {
+		return info
 	}
-	if m.Flow != "" {
-		info = append(info, yaml.MapItem{Key: "flow", Value: m.Flow})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "type", Value: m.Type})
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "flow", Value: m.Flow})
 	if m.Scopes != nil {
 		info = append(info, yaml.MapItem{Key: "scopes", Value: m.Scopes.ToRawInfo()})
 	}
 	// &{Name:scopes Type:Oauth2Scopes StringEnumValues:[] MapType: Repeated:false Pattern: Implicit:false Description:}
-	if m.TokenUrl != "" {
-		info = append(info, yaml.MapItem{Key: "tokenUrl", Value: m.TokenUrl})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "tokenUrl", Value: m.TokenUrl})
 	if m.Description != "" {
 		info = append(info, yaml.MapItem{Key: "description", Value: m.Description})
 	}
@@ -7882,19 +7948,19 @@ func (m *Oauth2ApplicationSecurity) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Oauth2ImplicitSecurity suitable for JSON or YAML export.
 func (m *Oauth2ImplicitSecurity) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
-	if m.Type != "" {
-		info = append(info, yaml.MapItem{Key: "type", Value: m.Type})
+	if m == nil {
+		return info
 	}
-	if m.Flow != "" {
-		info = append(info, yaml.MapItem{Key: "flow", Value: m.Flow})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "type", Value: m.Type})
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "flow", Value: m.Flow})
 	if m.Scopes != nil {
 		info = append(info, yaml.MapItem{Key: "scopes", Value: m.Scopes.ToRawInfo()})
 	}
 	// &{Name:scopes Type:Oauth2Scopes StringEnumValues:[] MapType: Repeated:false Pattern: Implicit:false Description:}
-	if m.AuthorizationUrl != "" {
-		info = append(info, yaml.MapItem{Key: "authorizationUrl", Value: m.AuthorizationUrl})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "authorizationUrl", Value: m.AuthorizationUrl})
 	if m.Description != "" {
 		info = append(info, yaml.MapItem{Key: "description", Value: m.Description})
 	}
@@ -7910,19 +7976,19 @@ func (m *Oauth2ImplicitSecurity) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Oauth2PasswordSecurity suitable for JSON or YAML export.
 func (m *Oauth2PasswordSecurity) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
-	if m.Type != "" {
-		info = append(info, yaml.MapItem{Key: "type", Value: m.Type})
+	if m == nil {
+		return info
 	}
-	if m.Flow != "" {
-		info = append(info, yaml.MapItem{Key: "flow", Value: m.Flow})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "type", Value: m.Type})
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "flow", Value: m.Flow})
 	if m.Scopes != nil {
 		info = append(info, yaml.MapItem{Key: "scopes", Value: m.Scopes.ToRawInfo()})
 	}
 	// &{Name:scopes Type:Oauth2Scopes StringEnumValues:[] MapType: Repeated:false Pattern: Implicit:false Description:}
-	if m.TokenUrl != "" {
-		info = append(info, yaml.MapItem{Key: "tokenUrl", Value: m.TokenUrl})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "tokenUrl", Value: m.TokenUrl})
 	if m.Description != "" {
 		info = append(info, yaml.MapItem{Key: "description", Value: m.Description})
 	}
@@ -7938,6 +8004,9 @@ func (m *Oauth2PasswordSecurity) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Oauth2Scopes suitable for JSON or YAML export.
 func (m *Oauth2Scopes) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	// &{Name:additionalProperties Type:NamedString StringEnumValues:[] MapType:string Repeated:true Pattern: Implicit:true Description:}
 	return info
 }
@@ -7945,6 +8014,9 @@ func (m *Oauth2Scopes) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Operation suitable for JSON or YAML export.
 func (m *Operation) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if len(m.Tags) != 0 {
 		info = append(info, yaml.MapItem{Key: "tags", Value: m.Tags})
 	}
@@ -7975,9 +8047,8 @@ func (m *Operation) ToRawInfo() interface{} {
 		info = append(info, yaml.MapItem{Key: "parameters", Value: items})
 	}
 	// &{Name:parameters Type:ParametersItem StringEnumValues:[] MapType: Repeated:true Pattern: Implicit:false Description:The parameters needed to send a valid API call.}
-	if m.Responses != nil {
-		info = append(info, yaml.MapItem{Key: "responses", Value: m.Responses.ToRawInfo()})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "responses", Value: m.Responses.ToRawInfo()})
 	// &{Name:responses Type:Responses StringEnumValues:[] MapType: Repeated:false Pattern: Implicit:false Description:}
 	if len(m.Schemes) != 0 {
 		info = append(info, yaml.MapItem{Key: "schemes", Value: m.Schemes})
@@ -8022,6 +8093,9 @@ func (m *Parameter) ToRawInfo() interface{} {
 // ToRawInfo returns a description of ParameterDefinitions suitable for JSON or YAML export.
 func (m *ParameterDefinitions) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -8051,6 +8125,9 @@ func (m *ParametersItem) ToRawInfo() interface{} {
 // ToRawInfo returns a description of PathItem suitable for JSON or YAML export.
 func (m *PathItem) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.XRef != "" {
 		info = append(info, yaml.MapItem{Key: "$ref", Value: m.XRef})
 	}
@@ -8102,9 +8179,11 @@ func (m *PathItem) ToRawInfo() interface{} {
 // ToRawInfo returns a description of PathParameterSubSchema suitable for JSON or YAML export.
 func (m *PathParameterSubSchema) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
-	if m.Required != false {
-		info = append(info, yaml.MapItem{Key: "required", Value: m.Required})
+	if m == nil {
+		return info
 	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "required", Value: m.Required})
 	if m.In != "" {
 		info = append(info, yaml.MapItem{Key: "in", Value: m.In})
 	}
@@ -8184,6 +8263,9 @@ func (m *PathParameterSubSchema) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Paths suitable for JSON or YAML export.
 func (m *Paths) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.VendorExtension != nil {
 		for _, item := range m.VendorExtension {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -8202,6 +8284,9 @@ func (m *Paths) ToRawInfo() interface{} {
 // ToRawInfo returns a description of PrimitivesItems suitable for JSON or YAML export.
 func (m *PrimitivesItems) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Type != "" {
 		info = append(info, yaml.MapItem{Key: "type", Value: m.Type})
 	}
@@ -8272,6 +8357,9 @@ func (m *PrimitivesItems) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Properties suitable for JSON or YAML export.
 func (m *Properties) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -8284,6 +8372,9 @@ func (m *Properties) ToRawInfo() interface{} {
 // ToRawInfo returns a description of QueryParameterSubSchema suitable for JSON or YAML export.
 func (m *QueryParameterSubSchema) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Required != false {
 		info = append(info, yaml.MapItem{Key: "required", Value: m.Required})
 	}
@@ -8369,9 +8460,11 @@ func (m *QueryParameterSubSchema) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Response suitable for JSON or YAML export.
 func (m *Response) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
-	if m.Description != "" {
-		info = append(info, yaml.MapItem{Key: "description", Value: m.Description})
+	if m == nil {
+		return info
 	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "description", Value: m.Description})
 	if m.Schema != nil {
 		info = append(info, yaml.MapItem{Key: "schema", Value: m.Schema.ToRawInfo()})
 	}
@@ -8396,6 +8489,9 @@ func (m *Response) ToRawInfo() interface{} {
 // ToRawInfo returns a description of ResponseDefinitions suitable for JSON or YAML export.
 func (m *ResponseDefinitions) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -8425,6 +8521,9 @@ func (m *ResponseValue) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Responses suitable for JSON or YAML export.
 func (m *Responses) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.ResponseCode != nil {
 		for _, item := range m.ResponseCode {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -8443,6 +8542,9 @@ func (m *Responses) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Schema suitable for JSON or YAML export.
 func (m *Schema) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.XRef != "" {
 		info = append(info, yaml.MapItem{Key: "$ref", Value: m.XRef})
 	}
@@ -8588,6 +8690,9 @@ func (m *SchemaItem) ToRawInfo() interface{} {
 // ToRawInfo returns a description of SecurityDefinitions suitable for JSON or YAML export.
 func (m *SecurityDefinitions) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -8637,6 +8742,9 @@ func (m *SecurityDefinitionsItem) ToRawInfo() interface{} {
 // ToRawInfo returns a description of SecurityRequirement suitable for JSON or YAML export.
 func (m *SecurityRequirement) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -8654,9 +8762,11 @@ func (m *StringArray) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Tag suitable for JSON or YAML export.
 func (m *Tag) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
-	if m.Name != "" {
-		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
+	if m == nil {
+		return info
 	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	if m.Description != "" {
 		info = append(info, yaml.MapItem{Key: "description", Value: m.Description})
 	}
@@ -8676,6 +8786,9 @@ func (m *Tag) ToRawInfo() interface{} {
 // ToRawInfo returns a description of TypeItem suitable for JSON or YAML export.
 func (m *TypeItem) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if len(m.Value) != 0 {
 		info = append(info, yaml.MapItem{Key: "value", Value: m.Value})
 	}
@@ -8685,6 +8798,9 @@ func (m *TypeItem) ToRawInfo() interface{} {
 // ToRawInfo returns a description of VendorExtension suitable for JSON or YAML export.
 func (m *VendorExtension) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -8697,6 +8813,9 @@ func (m *VendorExtension) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Xml suitable for JSON or YAML export.
 func (m *Xml) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}

--- a/OpenAPIv3/OpenAPIv3.go
+++ b/OpenAPIv3/OpenAPIv3.go
@@ -6714,6 +6714,9 @@ func (m *AnyOrExpression) ToRawInfo() interface{} {
 // ToRawInfo returns a description of AnysOrExpressions suitable for JSON or YAML export.
 func (m *AnysOrExpressions) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -6726,6 +6729,9 @@ func (m *AnysOrExpressions) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Callback suitable for JSON or YAML export.
 func (m *Callback) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Path != nil {
 		for _, item := range m.Path {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -6761,6 +6767,9 @@ func (m *CallbackOrReference) ToRawInfo() interface{} {
 // ToRawInfo returns a description of CallbacksOrReferences suitable for JSON or YAML export.
 func (m *CallbacksOrReferences) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -6773,6 +6782,9 @@ func (m *CallbacksOrReferences) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Components suitable for JSON or YAML export.
 func (m *Components) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Schemas != nil {
 		info = append(info, yaml.MapItem{Key: "schemas", Value: m.Schemas.ToRawInfo()})
 	}
@@ -6821,6 +6833,9 @@ func (m *Components) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Contact suitable for JSON or YAML export.
 func (m *Contact) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -6861,9 +6876,11 @@ func (m *DefaultType) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Discriminator suitable for JSON or YAML export.
 func (m *Discriminator) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
-	if m.PropertyName != "" {
-		info = append(info, yaml.MapItem{Key: "propertyName", Value: m.PropertyName})
+	if m == nil {
+		return info
 	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "propertyName", Value: m.PropertyName})
 	if m.Mapping != nil {
 		info = append(info, yaml.MapItem{Key: "mapping", Value: m.Mapping.ToRawInfo()})
 	}
@@ -6874,12 +6891,13 @@ func (m *Discriminator) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Document suitable for JSON or YAML export.
 func (m *Document) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
-	if m.Openapi != "" {
-		info = append(info, yaml.MapItem{Key: "openapi", Value: m.Openapi})
+	if m == nil {
+		return info
 	}
-	if m.Info != nil {
-		info = append(info, yaml.MapItem{Key: "info", Value: m.Info.ToRawInfo()})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "openapi", Value: m.Openapi})
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "info", Value: m.Info.ToRawInfo()})
 	// &{Name:info Type:Info StringEnumValues:[] MapType: Repeated:false Pattern: Implicit:false Description:}
 	if len(m.Servers) != 0 {
 		items := make([]interface{}, 0)
@@ -6889,9 +6907,8 @@ func (m *Document) ToRawInfo() interface{} {
 		info = append(info, yaml.MapItem{Key: "servers", Value: items})
 	}
 	// &{Name:servers Type:Server StringEnumValues:[] MapType: Repeated:true Pattern: Implicit:false Description:}
-	if m.Paths != nil {
-		info = append(info, yaml.MapItem{Key: "paths", Value: m.Paths.ToRawInfo()})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "paths", Value: m.Paths.ToRawInfo()})
 	// &{Name:paths Type:Paths StringEnumValues:[] MapType: Repeated:false Pattern: Implicit:false Description:}
 	if m.Components != nil {
 		info = append(info, yaml.MapItem{Key: "components", Value: m.Components.ToRawInfo()})
@@ -6929,6 +6946,9 @@ func (m *Document) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Encoding suitable for JSON or YAML export.
 func (m *Encoding) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.ContentType != "" {
 		info = append(info, yaml.MapItem{Key: "contentType", Value: m.ContentType})
 	}
@@ -6957,6 +6977,9 @@ func (m *Encoding) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Encodings suitable for JSON or YAML export.
 func (m *Encodings) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -6969,6 +6992,9 @@ func (m *Encodings) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Example suitable for JSON or YAML export.
 func (m *Example) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Summary != "" {
 		info = append(info, yaml.MapItem{Key: "summary", Value: m.Summary})
 	}
@@ -7008,6 +7034,9 @@ func (m *ExampleOrReference) ToRawInfo() interface{} {
 // ToRawInfo returns a description of ExamplesOrReferences suitable for JSON or YAML export.
 func (m *ExamplesOrReferences) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -7020,6 +7049,9 @@ func (m *ExamplesOrReferences) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Expression suitable for JSON or YAML export.
 func (m *Expression) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -7032,12 +7064,14 @@ func (m *Expression) ToRawInfo() interface{} {
 // ToRawInfo returns a description of ExternalDocs suitable for JSON or YAML export.
 func (m *ExternalDocs) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Description != "" {
 		info = append(info, yaml.MapItem{Key: "description", Value: m.Description})
 	}
-	if m.Url != "" {
-		info = append(info, yaml.MapItem{Key: "url", Value: m.Url})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "url", Value: m.Url})
 	if m.SpecificationExtension != nil {
 		for _, item := range m.SpecificationExtension {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -7050,6 +7084,9 @@ func (m *ExternalDocs) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Header suitable for JSON or YAML export.
 func (m *Header) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Description != "" {
 		info = append(info, yaml.MapItem{Key: "description", Value: m.Description})
 	}
@@ -7116,6 +7153,9 @@ func (m *HeaderOrReference) ToRawInfo() interface{} {
 // ToRawInfo returns a description of HeadersOrReferences suitable for JSON or YAML export.
 func (m *HeadersOrReferences) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -7128,9 +7168,11 @@ func (m *HeadersOrReferences) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Info suitable for JSON or YAML export.
 func (m *Info) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
-	if m.Title != "" {
-		info = append(info, yaml.MapItem{Key: "title", Value: m.Title})
+	if m == nil {
+		return info
 	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "title", Value: m.Title})
 	if m.Description != "" {
 		info = append(info, yaml.MapItem{Key: "description", Value: m.Description})
 	}
@@ -7145,9 +7187,8 @@ func (m *Info) ToRawInfo() interface{} {
 		info = append(info, yaml.MapItem{Key: "license", Value: m.License.ToRawInfo()})
 	}
 	// &{Name:license Type:License StringEnumValues:[] MapType: Repeated:false Pattern: Implicit:false Description:}
-	if m.Version != "" {
-		info = append(info, yaml.MapItem{Key: "version", Value: m.Version})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "version", Value: m.Version})
 	if m.SpecificationExtension != nil {
 		for _, item := range m.SpecificationExtension {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -7160,6 +7201,9 @@ func (m *Info) ToRawInfo() interface{} {
 // ToRawInfo returns a description of ItemsItem suitable for JSON or YAML export.
 func (m *ItemsItem) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if len(m.SchemaOrReference) != 0 {
 		items := make([]interface{}, 0)
 		for _, item := range m.SchemaOrReference {
@@ -7174,9 +7218,11 @@ func (m *ItemsItem) ToRawInfo() interface{} {
 // ToRawInfo returns a description of License suitable for JSON or YAML export.
 func (m *License) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
-	if m.Name != "" {
-		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
+	if m == nil {
+		return info
 	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	if m.Url != "" {
 		info = append(info, yaml.MapItem{Key: "url", Value: m.Url})
 	}
@@ -7192,6 +7238,9 @@ func (m *License) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Link suitable for JSON or YAML export.
 func (m *Link) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.OperationRef != "" {
 		info = append(info, yaml.MapItem{Key: "operationRef", Value: m.OperationRef})
 	}
@@ -7242,6 +7291,9 @@ func (m *LinkOrReference) ToRawInfo() interface{} {
 // ToRawInfo returns a description of LinksOrReferences suitable for JSON or YAML export.
 func (m *LinksOrReferences) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -7254,6 +7306,9 @@ func (m *LinksOrReferences) ToRawInfo() interface{} {
 // ToRawInfo returns a description of MediaType suitable for JSON or YAML export.
 func (m *MediaType) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Schema != nil {
 		info = append(info, yaml.MapItem{Key: "schema", Value: m.Schema.ToRawInfo()})
 	}
@@ -7282,6 +7337,9 @@ func (m *MediaType) ToRawInfo() interface{} {
 // ToRawInfo returns a description of MediaTypes suitable for JSON or YAML export.
 func (m *MediaTypes) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -7294,6 +7352,9 @@ func (m *MediaTypes) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedAny suitable for JSON or YAML export.
 func (m *NamedAny) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7304,6 +7365,9 @@ func (m *NamedAny) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedAnyOrExpression suitable for JSON or YAML export.
 func (m *NamedAnyOrExpression) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7314,6 +7378,9 @@ func (m *NamedAnyOrExpression) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedCallbackOrReference suitable for JSON or YAML export.
 func (m *NamedCallbackOrReference) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7324,6 +7391,9 @@ func (m *NamedCallbackOrReference) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedEncoding suitable for JSON or YAML export.
 func (m *NamedEncoding) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7334,6 +7404,9 @@ func (m *NamedEncoding) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedExampleOrReference suitable for JSON or YAML export.
 func (m *NamedExampleOrReference) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7344,6 +7417,9 @@ func (m *NamedExampleOrReference) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedHeaderOrReference suitable for JSON or YAML export.
 func (m *NamedHeaderOrReference) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7354,6 +7430,9 @@ func (m *NamedHeaderOrReference) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedLinkOrReference suitable for JSON or YAML export.
 func (m *NamedLinkOrReference) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7364,6 +7443,9 @@ func (m *NamedLinkOrReference) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedMediaType suitable for JSON or YAML export.
 func (m *NamedMediaType) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7374,6 +7456,9 @@ func (m *NamedMediaType) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedParameterOrReference suitable for JSON or YAML export.
 func (m *NamedParameterOrReference) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7384,6 +7469,9 @@ func (m *NamedParameterOrReference) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedPathItem suitable for JSON or YAML export.
 func (m *NamedPathItem) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7394,6 +7482,9 @@ func (m *NamedPathItem) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedRequestBodyOrReference suitable for JSON or YAML export.
 func (m *NamedRequestBodyOrReference) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7404,6 +7495,9 @@ func (m *NamedRequestBodyOrReference) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedResponseOrReference suitable for JSON or YAML export.
 func (m *NamedResponseOrReference) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7414,6 +7508,9 @@ func (m *NamedResponseOrReference) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedSchemaOrReference suitable for JSON or YAML export.
 func (m *NamedSchemaOrReference) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7424,6 +7521,9 @@ func (m *NamedSchemaOrReference) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedSecuritySchemeOrReference suitable for JSON or YAML export.
 func (m *NamedSecuritySchemeOrReference) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7434,6 +7534,9 @@ func (m *NamedSecuritySchemeOrReference) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedServerVariable suitable for JSON or YAML export.
 func (m *NamedServerVariable) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7444,6 +7547,9 @@ func (m *NamedServerVariable) ToRawInfo() interface{} {
 // ToRawInfo returns a description of NamedString suitable for JSON or YAML export.
 func (m *NamedString) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}
@@ -7456,6 +7562,9 @@ func (m *NamedString) ToRawInfo() interface{} {
 // ToRawInfo returns a description of OauthFlow suitable for JSON or YAML export.
 func (m *OauthFlow) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AuthorizationUrl != "" {
 		info = append(info, yaml.MapItem{Key: "authorizationUrl", Value: m.AuthorizationUrl})
 	}
@@ -7481,6 +7590,9 @@ func (m *OauthFlow) ToRawInfo() interface{} {
 // ToRawInfo returns a description of OauthFlows suitable for JSON or YAML export.
 func (m *OauthFlows) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Implicit != nil {
 		info = append(info, yaml.MapItem{Key: "implicit", Value: m.Implicit.ToRawInfo()})
 	}
@@ -7509,6 +7621,9 @@ func (m *OauthFlows) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Object suitable for JSON or YAML export.
 func (m *Object) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -7521,6 +7636,9 @@ func (m *Object) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Operation suitable for JSON or YAML export.
 func (m *Operation) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if len(m.Tags) != 0 {
 		info = append(info, yaml.MapItem{Key: "tags", Value: m.Tags})
 	}
@@ -7549,9 +7667,8 @@ func (m *Operation) ToRawInfo() interface{} {
 		info = append(info, yaml.MapItem{Key: "requestBody", Value: m.RequestBody.ToRawInfo()})
 	}
 	// &{Name:requestBody Type:RequestBodyOrReference StringEnumValues:[] MapType: Repeated:false Pattern: Implicit:false Description:}
-	if m.Responses != nil {
-		info = append(info, yaml.MapItem{Key: "responses", Value: m.Responses.ToRawInfo()})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "responses", Value: m.Responses.ToRawInfo()})
 	// &{Name:responses Type:Responses StringEnumValues:[] MapType: Repeated:false Pattern: Implicit:false Description:}
 	if m.Callbacks != nil {
 		info = append(info, yaml.MapItem{Key: "callbacks", Value: m.Callbacks.ToRawInfo()})
@@ -7588,12 +7705,13 @@ func (m *Operation) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Parameter suitable for JSON or YAML export.
 func (m *Parameter) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
-	if m.Name != "" {
-		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
+	if m == nil {
+		return info
 	}
-	if m.In != "" {
-		info = append(info, yaml.MapItem{Key: "in", Value: m.In})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "in", Value: m.In})
 	if m.Description != "" {
 		info = append(info, yaml.MapItem{Key: "description", Value: m.Description})
 	}
@@ -7660,6 +7778,9 @@ func (m *ParameterOrReference) ToRawInfo() interface{} {
 // ToRawInfo returns a description of ParametersOrReferences suitable for JSON or YAML export.
 func (m *ParametersOrReferences) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -7672,6 +7793,9 @@ func (m *ParametersOrReferences) ToRawInfo() interface{} {
 // ToRawInfo returns a description of PathItem suitable for JSON or YAML export.
 func (m *PathItem) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.XRef != "" {
 		info = append(info, yaml.MapItem{Key: "$ref", Value: m.XRef})
 	}
@@ -7741,6 +7865,9 @@ func (m *PathItem) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Paths suitable for JSON or YAML export.
 func (m *Paths) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Path != nil {
 		for _, item := range m.Path {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -7759,6 +7886,9 @@ func (m *Paths) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Properties suitable for JSON or YAML export.
 func (m *Properties) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -7771,15 +7901,20 @@ func (m *Properties) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Reference suitable for JSON or YAML export.
 func (m *Reference) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
-	if m.XRef != "" {
-		info = append(info, yaml.MapItem{Key: "$ref", Value: m.XRef})
+	if m == nil {
+		return info
 	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "$ref", Value: m.XRef})
 	return info
 }
 
 // ToRawInfo returns a description of RequestBodiesOrReferences suitable for JSON or YAML export.
 func (m *RequestBodiesOrReferences) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -7792,12 +7927,14 @@ func (m *RequestBodiesOrReferences) ToRawInfo() interface{} {
 // ToRawInfo returns a description of RequestBody suitable for JSON or YAML export.
 func (m *RequestBody) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Description != "" {
 		info = append(info, yaml.MapItem{Key: "description", Value: m.Description})
 	}
-	if m.Content != nil {
-		info = append(info, yaml.MapItem{Key: "content", Value: m.Content.ToRawInfo()})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "content", Value: m.Content.ToRawInfo()})
 	// &{Name:content Type:MediaTypes StringEnumValues:[] MapType: Repeated:false Pattern: Implicit:false Description:}
 	if m.Required != false {
 		info = append(info, yaml.MapItem{Key: "required", Value: m.Required})
@@ -7831,9 +7968,11 @@ func (m *RequestBodyOrReference) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Response suitable for JSON or YAML export.
 func (m *Response) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
-	if m.Description != "" {
-		info = append(info, yaml.MapItem{Key: "description", Value: m.Description})
+	if m == nil {
+		return info
 	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "description", Value: m.Description})
 	if m.Headers != nil {
 		info = append(info, yaml.MapItem{Key: "headers", Value: m.Headers.ToRawInfo()})
 	}
@@ -7875,6 +8014,9 @@ func (m *ResponseOrReference) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Responses suitable for JSON or YAML export.
 func (m *Responses) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Default != nil {
 		info = append(info, yaml.MapItem{Key: "default", Value: m.Default.ToRawInfo()})
 	}
@@ -7897,6 +8039,9 @@ func (m *Responses) ToRawInfo() interface{} {
 // ToRawInfo returns a description of ResponsesOrReferences suitable for JSON or YAML export.
 func (m *ResponsesOrReferences) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -7909,6 +8054,9 @@ func (m *ResponsesOrReferences) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Schema suitable for JSON or YAML export.
 func (m *Schema) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Nullable != false {
 		info = append(info, yaml.MapItem{Key: "nullable", Value: m.Nullable})
 	}
@@ -8076,6 +8224,9 @@ func (m *SchemaOrReference) ToRawInfo() interface{} {
 // ToRawInfo returns a description of SchemasOrReferences suitable for JSON or YAML export.
 func (m *SchemasOrReferences) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -8088,15 +8239,20 @@ func (m *SchemasOrReferences) ToRawInfo() interface{} {
 // ToRawInfo returns a description of SecurityRequirement suitable for JSON or YAML export.
 func (m *SecurityRequirement) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	return info
 }
 
 // ToRawInfo returns a description of SecurityScheme suitable for JSON or YAML export.
 func (m *SecurityScheme) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
-	if m.Type != "" {
-		info = append(info, yaml.MapItem{Key: "type", Value: m.Type})
+	if m == nil {
+		return info
 	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "type", Value: m.Type})
 	if m.Description != "" {
 		info = append(info, yaml.MapItem{Key: "description", Value: m.Description})
 	}
@@ -8148,6 +8304,9 @@ func (m *SecuritySchemeOrReference) ToRawInfo() interface{} {
 // ToRawInfo returns a description of SecuritySchemesOrReferences suitable for JSON or YAML export.
 func (m *SecuritySchemesOrReferences) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -8160,9 +8319,11 @@ func (m *SecuritySchemesOrReferences) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Server suitable for JSON or YAML export.
 func (m *Server) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
-	if m.Url != "" {
-		info = append(info, yaml.MapItem{Key: "url", Value: m.Url})
+	if m == nil {
+		return info
 	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "url", Value: m.Url})
 	if m.Description != "" {
 		info = append(info, yaml.MapItem{Key: "description", Value: m.Description})
 	}
@@ -8182,12 +8343,14 @@ func (m *Server) ToRawInfo() interface{} {
 // ToRawInfo returns a description of ServerVariable suitable for JSON or YAML export.
 func (m *ServerVariable) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if len(m.Enum) != 0 {
 		info = append(info, yaml.MapItem{Key: "enum", Value: m.Enum})
 	}
-	if m.Default != "" {
-		info = append(info, yaml.MapItem{Key: "default", Value: m.Default})
-	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "default", Value: m.Default})
 	if m.Description != "" {
 		info = append(info, yaml.MapItem{Key: "description", Value: m.Description})
 	}
@@ -8203,6 +8366,9 @@ func (m *ServerVariable) ToRawInfo() interface{} {
 // ToRawInfo returns a description of ServerVariables suitable for JSON or YAML export.
 func (m *ServerVariables) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.AdditionalProperties != nil {
 		for _, item := range m.AdditionalProperties {
 			info = append(info, yaml.MapItem{Key: item.Name, Value: item.Value.ToRawInfo()})
@@ -8239,6 +8405,9 @@ func (m *StringArray) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Strings suitable for JSON or YAML export.
 func (m *Strings) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	// &{Name:additionalProperties Type:NamedString StringEnumValues:[] MapType:string Repeated:true Pattern: Implicit:true Description:}
 	return info
 }
@@ -8246,9 +8415,11 @@ func (m *Strings) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Tag suitable for JSON or YAML export.
 func (m *Tag) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
-	if m.Name != "" {
-		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
+	if m == nil {
+		return info
 	}
+	// always include this required field.
+	info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	if m.Description != "" {
 		info = append(info, yaml.MapItem{Key: "description", Value: m.Description})
 	}
@@ -8268,6 +8439,9 @@ func (m *Tag) ToRawInfo() interface{} {
 // ToRawInfo returns a description of Xml suitable for JSON or YAML export.
 func (m *Xml) ToRawInfo() interface{} {
 	info := yaml.MapSlice{}
+	if m == nil {
+		return info
+	}
 	if m.Name != "" {
 		info = append(info, yaml.MapItem{Key: "name", Value: m.Name})
 	}

--- a/examples/v2.0/yaml/empty-v2.yaml
+++ b/examples/v2.0/yaml/empty-v2.yaml
@@ -1,0 +1,6 @@
+swagger: "2.0"
+info:
+  version: ""
+  title: ""
+  description: ""
+paths:

--- a/examples/v3.0/yaml/empty-v3.yaml
+++ b/examples/v3.0/yaml/empty-v3.yaml
@@ -1,0 +1,6 @@
+openapi: "3.0"
+info:
+  version: 
+  title: 
+  description: 
+paths:

--- a/generate-gnostic/types.go
+++ b/generate-gnostic/types.go
@@ -130,3 +130,12 @@ func NewTypeModel() *TypeModel {
 	typeModel.Properties = make([]*TypeProperty, 0)
 	return typeModel
 }
+
+func (typeModel *TypeModel) IsRequired(propertyName string) bool {
+	for _, requiredName := range typeModel.Required {
+		if requiredName == propertyName {
+			return true
+		}
+	}
+	return false
+}

--- a/printer/code.go
+++ b/printer/code.go
@@ -38,6 +38,20 @@ func (c *Code) Print(args ...interface{}) {
 	c.text += "\n"
 }
 
+// PrintIf adds a line of code using the current indentation if a condition is true. Accepts printf-style format strings and arguments.
+func (c *Code) PrintIf(condition bool, args ...interface{}) {
+	if !condition {
+		return
+	}
+	if len(args) > 0 {
+		for i := 0; i < c.indent; i++ {
+			c.text += indentation
+		}
+		c.text += fmt.Sprintf(args[0].(string), args[1:]...)
+	}
+	c.text += "\n"
+}
+
 // String returns the accumulated code as a string.
 func (c *Code) String() string {
 	return c.text

--- a/surface/model_openapiv2.go
+++ b/surface/model_openapiv2.go
@@ -58,19 +58,21 @@ func (b *OpenAPI2Builder) build(document *openapiv2.Document) (err error) {
 		}
 	}
 	// Collect service method descriptions from Paths section.
-	for _, pair := range document.Paths.Path {
-		v := pair.Value
-		if v.Get != nil {
-			b.buildMethodFromOperation(v.Get, "GET", pair.Name)
-		}
-		if v.Post != nil {
-			b.buildMethodFromOperation(v.Post, "POST", pair.Name)
-		}
-		if v.Put != nil {
-			b.buildMethodFromOperation(v.Put, "PUT", pair.Name)
-		}
-		if v.Delete != nil {
-			b.buildMethodFromOperation(v.Delete, "DELETE", pair.Name)
+	if document.Paths != nil {
+		for _, pair := range document.Paths.Path {
+			v := pair.Value
+			if v.Get != nil {
+				b.buildMethodFromOperation(v.Get, "GET", pair.Name)
+			}
+			if v.Post != nil {
+				b.buildMethodFromOperation(v.Post, "POST", pair.Name)
+			}
+			if v.Put != nil {
+				b.buildMethodFromOperation(v.Put, "PUT", pair.Name)
+			}
+			if v.Delete != nil {
+				b.buildMethodFromOperation(v.Delete, "DELETE", pair.Name)
+			}
 		}
 	}
 	return err

--- a/surface/model_openapiv3.go
+++ b/surface/model_openapiv3.go
@@ -64,8 +64,10 @@ func (b *OpenAPI3Builder) build(document *openapiv3.Document) (err error) {
 		}
 	}
 	// Collect service method descriptions from each PathItem.
-	for _, pair := range document.Paths.Path {
-		b.buildMethodFromPathItem(pair.Name, pair.Value)
+	if document.Paths != nil {
+		for _, pair := range document.Paths.Path {
+			b.buildMethodFromPathItem(pair.Name, pair.Value)
+		}
 	}
 	return err
 }

--- a/test/v2.0/json/empty-v2.json
+++ b/test/v2.0/json/empty-v2.json
@@ -1,0 +1,9 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "",
+    "version": ""
+  },
+  "paths": {
+  }
+}

--- a/test/v3.0/json/empty-v3.json
+++ b/test/v3.0/json/empty-v3.json
@@ -1,0 +1,9 @@
+{
+  "openapi": "3.0",
+  "info": {
+    "title": "",
+    "version": ""
+  },
+  "paths": {
+  }
+}


### PR DESCRIPTION
Prior to this change, required fields would be omitted if they
were set to their default values.

Reported in GitHub Issue #82.