### PR TITLE
fix silent plugin failures & goimports dep

### DIFF
--- a/.travis-install.sh
+++ b/.travis-install.sh
@@ -14,7 +14,7 @@ cd
 mkdir -p local
 
 # Install swift
-SWIFT_URL=https://swift.org/builds/swift-4.0-branch/ubuntu1404/swift-4.0-DEVELOPMENT-SNAPSHOT-2017-09-01-a/swift-4.0-DEVELOPMENT-SNAPSHOT-2017-09-01-a-ubuntu14.04.tar.gz
+SWIFT_URL=https://swift.org/builds/swift-4.2-release/ubuntu1404/swift-4.2-RELEASE/swift-4.2-RELEASE-ubuntu14.04.tar.gz
 echo $SWIFT_URL
 curl -fSsL $SWIFT_URL -o swift.tar.gz 
 tar -xzf swift.tar.gz --strip-components=2 --directory=local

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 	cd apps/petstore-builder; go get; go install
 	cd plugins/gnostic-summary; go get; go install
 	cd plugins/gnostic-analyze; go get; go install
-	cd plugins/gnostic-go-generator; go get; go install
+	cd plugins/gnostic-go-generator; go get; go get golang.org/x/tools/cmd/goimports; go install
 	rm -f $(GOPATH)/bin/gnostic-go-client $(GOPATH)/bin/gnostic-go-server
 	ln -s $(GOPATH)/bin/gnostic-go-generator $(GOPATH)/bin/gnostic-go-client
 	ln -s $(GOPATH)/bin/gnostic-go-generator $(GOPATH)/bin/gnostic-go-server

--- a/gnostic.go
+++ b/gnostic.go
@@ -186,8 +186,10 @@ func (p *pluginCall) perform(document proto.Message, sourceFormat int, sourceNam
 			// any logging messages are written to stderr only.
 			return nil, errors.New("Invalid plugin response (plugins must write log messages to stderr, not stdout).")
 		}
-		plugins.HandleResponse(response, outputLocation)
-		return response.Messages, nil
+
+		err = plugins.HandleResponse(response, outputLocation)
+
+		return response.Messages, err
 	}
 	return nil, nil
 }


### PR DESCRIPTION
* `goimports` wasn't explicitly installed by root `make build`, but is exec'd by `gnostic-go-generator` plugin (it is installed by the plugin's target).
* plugins were failing silently because `plugins.HandleResponse` return value (the potential plugin error) was being ignored