### PR TITLE
remove install & tests for swift

### DIFF
--- a/.travis-install.sh
+++ b/.travis-install.sh
@@ -13,12 +13,6 @@
 cd
 mkdir -p local
 
-# Install swift
-SWIFT_URL=https://swift.org/builds/swift-4.2-release/ubuntu1404/swift-4.2-RELEASE/swift-4.2-RELEASE-ubuntu14.04.tar.gz
-echo $SWIFT_URL
-curl -fSsL $SWIFT_URL -o swift.tar.gz 
-tar -xzf swift.tar.gz --strip-components=2 --directory=local
-
 # Install protoc
 PROTOC_URL=https://github.com/google/protobuf/releases/download/v3.4.0/protoc-3.4.0-linux-x86_64.zip
 echo $PROTOC_URL

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,12 +38,4 @@ script:
   - pushd plugins/gnostic-go-generator/examples/v3.0/bookstore
   - make test
   - popd
-  - export PATH=.:$HOME/local/bin:$PATH
-  - export LD_LIBRARY_PATH=$HOME/local/lib
-  - pushd plugins/gnostic-swift-generator
-  - make install
-  - cd examples/bookstore
-  - make
-  - .build/debug/Server &
-  - make test
   


### PR DESCRIPTION
* removes `.travis-install.sh`
* removes gnostic-swift-generator install/tests from Travis

Decided in #95 conversation