### PR TITLE
Update apps/report sample to report better errors for non-OpenAPIv2 input.

### DIFF
--- a/apps/report/main.go
+++ b/apps/report/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 
 	"github.com/golang/protobuf/proto"
@@ -28,18 +29,17 @@ import (
 	pb "github.com/googleapis/gnostic/OpenAPIv2"
 )
 
-func readDocumentFromFileWithName(filename string) *pb.Document {
+func readDocumentFromFileWithName(filename string) (*pb.Document, error) {
 	data, err := ioutil.ReadFile(filename)
 	if err != nil {
-		fmt.Printf("File error: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 	document := &pb.Document{}
 	err = proto.Unmarshal(data, document)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	return document
+	return document, nil
 }
 
 func printDocument(code *printer.Code, document *pb.Document) {
@@ -229,8 +229,12 @@ func main() {
 		return
 	}
 
-	document := readDocumentFromFileWithName(args[0])
+	document, err := readDocumentFromFileWithName(args[0])
 
+	if err != nil {
+		log.Printf("Error reading %s. This sample expects OpenAPI v2.", args[0])
+		os.Exit(-1)
+	}
 	code := &printer.Code{}
 	code.Print("API REPORT")
 	code.Print("----------")


### PR DESCRIPTION
This fixes a panic reported in https://github.com/googleapis/gnostic/issues/98.

Underlying this, the apps/report sample is only written to support OpenAPIv2. It was crashing when given OpenAPIv3 input. We should probably also update apps/report to work with OpenAPIv3.