### PR TITLE
Resolve package name from output path

### DIFF
--- a/plugins/gnostic-go-generator/examples/v2.0/bookstore/Makefile
+++ b/plugins/gnostic-go-generator/examples/v2.0/bookstore/Makefile
@@ -1,5 +1,4 @@
 build:	
-	go get
 	go install github.com/googleapis/gnostic
 	go install github.com/googleapis/gnostic/plugins/gnostic-go-generator
 	rm -f $(GOPATH)/bin/gnostic-go-client $(GOPATH)/bin/gnostic-go-server

--- a/plugins/gnostic-go-generator/examples/v2.0/sample/Makefile
+++ b/plugins/gnostic-go-generator/examples/v2.0/sample/Makefile
@@ -1,5 +1,4 @@
 build:	
-	go get
 	go install github.com/googleapis/gnostic
 	go install github.com/googleapis/gnostic/plugins/gnostic-go-generator
 	rm -f $(GOPATH)/bin/gnostic-go-client $(GOPATH)/bin/gnostic-go-server

--- a/plugins/gnostic-go-generator/examples/v3.0/bookstore/Makefile
+++ b/plugins/gnostic-go-generator/examples/v3.0/bookstore/Makefile
@@ -1,5 +1,4 @@
 build:	
-	go get
 	go install github.com/googleapis/gnostic
 	go install github.com/googleapis/gnostic/plugins/gnostic-go-generator
 	rm -f $(GOPATH)/bin/gnostic-go-client $(GOPATH)/bin/gnostic-go-server

--- a/plugins/gnostic-go-generator/main.go
+++ b/plugins/gnostic-go-generator/main.go
@@ -78,6 +78,8 @@ func main() {
 	env.RespondAndExitIfError(err)
 }
 
+// resolvePackageName converts a path to a valid package name or
+// error if path can't be resolved or resolves to an invalid package name
 func resolvePackageName(p string) (string, error) {
 	p, err := filepath.Abs(p)
 	if err == nil {

--- a/plugins/gnostic-go-generator/main.go
+++ b/plugins/gnostic-go-generator/main.go
@@ -79,7 +79,7 @@ func main() {
 }
 
 // resolvePackageName converts a path to a valid package name or
-// error if path can't be resolved or resolves to an invalid package name
+// error if path can't be resolved or resolves to an invalid package name.
 func resolvePackageName(p string) (string, error) {
 	p, err := filepath.Abs(p)
 	if err == nil {


### PR DESCRIPTION
I wanted to be able to run -output . or -output /path/to/dir

Using format.Source was the easiest way I could figure out how to
validate the package name.

Relates to #111