### PR TITLE
Enhancements for the surface model

### DIFF
--- a/surface/model_openapiv3.go
+++ b/surface/model_openapiv3.go
@@ -383,7 +383,7 @@ func (b *OpenAPI3Builder) typeForSchema(schema *openapiv3.Schema) (kind FieldKin
 						return FieldKind_ARRAY, typeForRef(a[0].GetReference().GetXRef()), format
 					} else if knownTypes[a[0].GetSchema().Type] {
 						// The items of the array is one of the known types.
-						return FieldKind_ARRAY, a[0].GetSchema().Type, format
+						return FieldKind_ARRAY, a[0].GetSchema().Type, a[0].GetSchema().Format
 					}
 				}
 			}


### PR DESCRIPTION
- Surface model now includes types from components/Parameters, components/RequestBodies and components/Responses sections from the OpenAPI spec
- Surface model now includes types that use the reference object ($ref) inside of OpenAPI spec for parameters, request bodies, responses