### PR TITLE
Adding the position of a reference field.

### DIFF
--- a/surface/model_openapiv3.go
+++ b/surface/model_openapiv3.go
@@ -407,8 +407,8 @@ func (b *OpenAPI3Builder) typeForSchema(schema *openapiv3.Schema) (kind FieldKin
 		}
 	}
 	if schema.AdditionalProperties != nil {
-		schemarOrReference := schema.AdditionalProperties.GetSchemaOrReference()
-		k, t, f := b.typeForSchemaOrReference(schemarOrReference)
+		schemaOrReference := schema.AdditionalProperties.GetSchemaOrReference()
+		k, t, f := b.typeForSchemaOrReference(schemaOrReference)
 		mapValueType := ""
 		if k == FieldKind_ARRAY {
 			mapValueType = "[]"
@@ -416,7 +416,7 @@ func (b *OpenAPI3Builder) typeForSchema(schema *openapiv3.Schema) (kind FieldKin
 		if f != "" {
 			t = f
 		}
-		mapValueType = mapValueType + t
+		mapValueType += t
 		return FieldKind_MAP, "map[string]" + mapValueType, ""
 	}
 	// this function is incomplete... use generic interface{} for now

--- a/surface/model_openapiv3.go
+++ b/surface/model_openapiv3.go
@@ -407,12 +407,17 @@ func (b *OpenAPI3Builder) typeForSchema(schema *openapiv3.Schema) (kind FieldKin
 		}
 	}
 	if schema.AdditionalProperties != nil {
-		additionalProperties := schema.AdditionalProperties
-		if propertySchema := additionalProperties.GetSchemaOrReference().GetReference(); propertySchema != nil {
-			if ref := propertySchema.XRef; ref != "" {
-				return FieldKind_MAP, "map[string]" + typeForRef(ref), ""
-			}
+		schemarOrReference := schema.AdditionalProperties.GetSchemaOrReference()
+		k, t, f := b.typeForSchemaOrReference(schemarOrReference)
+		mapValueType := ""
+		if k == FieldKind_ARRAY {
+			mapValueType = "[]"
 		}
+		if f != "" {
+			t = f
+		}
+		mapValueType = mapValueType + t
+		return FieldKind_MAP, "map[string]" + mapValueType, ""
 	}
 	// this function is incomplete... use generic interface{} for now
 	log.Printf("unimplemented: %v", schema)

--- a/surface/model_openapiv3.go
+++ b/surface/model_openapiv3.go
@@ -332,7 +332,10 @@ func (b *OpenAPI3Builder) buildTypeFromResponses(
 		if response != nil && response.GetContent() != nil {
 			for _, pair2 := range response.GetContent().GetAdditionalProperties() {
 				f.Kind, f.Type, f.Format = b.typeForSchemaOrReference(pair2.GetValue().GetSchema())
-				t.addField(&f)
+
+				if !t.HasFieldWithName(f.Name) {
+					t.addField(&f)
+				}
 			}
 		} else if responseRef := value.GetReference(); responseRef != nil {
 			schemaOrReference := openapiv3.SchemaOrReference{&openapiv3.SchemaOrReference_Reference{Reference: responseRef}}

--- a/surface/model_openapiv3.go
+++ b/surface/model_openapiv3.go
@@ -250,6 +250,8 @@ func (b *OpenAPI3Builder) buildTypeFromParameters(
 			f.Type = typeForRef(parameterRef.GetXRef())
 			f.Name = strings.ToLower(f.Type)
 			f.Kind = FieldKind_REFERENCE
+			f.Position = b.positionForType(f.Type)
+
 			t.addField(&f)
 		}
 	}
@@ -412,4 +414,15 @@ func (b *OpenAPI3Builder) typeForSchema(schema *openapiv3.Schema) (kind FieldKin
 	// this function is incomplete... use generic interface{} for now
 	log.Printf("unimplemented: %v", schema)
 	return FieldKind_SCALAR, "object", ""
+}
+
+// Searches all types that have been created so far for the type with 'typeName' and
+// returns the position of the first field. Returns Position_BODY if there is no such type.
+func (b *OpenAPI3Builder) positionForType(typeName string) Position {
+	for _, t := range b.model.Types {
+		if t.Name == typeName {
+			return t.Fields[0].Position
+		}
+	}
+	return Position_BODY
 }

--- a/surface/type.go
+++ b/surface/type.go
@@ -26,11 +26,20 @@ func (s *Type) FieldWithName(name string) *Field {
 	if s == nil || s.Fields == nil || name == "" {
 		return nil
 	}
+	// Compares Go specific field names.
 	for _, f := range s.Fields {
 		if f.FieldName == name {
 			return f
 		}
 	}
+
+	// Compares names as specified in the OpenAPI description.
+	for _, f := range s.Fields {
+		if f.Name == name {
+			return f
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
#### Problem description:
Given following OpenAPI description: 

    paths:
      /testParameterReference:
        get:
          operationId: testParameterReference
          parameters:
            - $ref: '#/components/parameters/Parameter1'
          responses:
            200:
              description: success    
              
    components:
      parameters:
        Parameter1:
          name: param1
          in: query
          schema:
            type: integer
            format: int64
                  

The surface model creates a field with following properties:
![Screenshot from 2019-06-22 14-15-22](https://user-images.githubusercontent.com/12425139/59963802-9f7bc600-94f8-11e9-9c17-3200f46878ac.png)

Notice the Position property of the field that defaults to Position_BODY which is not correct.

#### Proposed solution
This PR sets the Position of the field to the referenced parameters position (in this case Position_QUERY).
An alternative solution would be to use a pointer for the 'Position' property and let it default to nil instead of Position_BODY.

Additionally, I am not sure about the [switch statement](https://github.com/LorenzHW/gnostic/blob/e6b1c2fad08b4c9c8abd19c877772ce33d0eeaef/surface/model_openapiv3.go#L231) above: according to the [OpenAPI spec](https://swagger.io/specification/#parameterObject)
the parameter object can only take: "header", "path", "query", or "cookie" for the 'in' field. I'd be happy to change that if necessary.

 
 

