### PR TITLE
Remove messages about responses with no contents.

### DIFF
--- a/surface/model_openapiv2.go
+++ b/surface/model_openapiv2.go
@@ -341,7 +341,6 @@ func (b *OpenAPI2Builder) buildFromResponse(name string, response *openapiv2.Res
 		fInfo = b.buildFromSchemaOrReference(name, response.Schema.GetSchema())
 		return fInfo
 	}
-	log.Printf("Couldn't build from response: %v", response)
 	return nil
 }
 

--- a/surface/model_openapiv3.go
+++ b/surface/model_openapiv3.go
@@ -329,7 +329,6 @@ func (b *OpenAPI3Builder) buildFromResponse(name string, response *openapiv3.Res
 		fInfo.fieldKind, fInfo.fieldType = FieldKind_REFERENCE, schemaType.Name
 		return fInfo
 	}
-	log.Printf("Response has no content: %v", name)
 	return nil
 }
 


### PR DESCRIPTION
During surface-building, we were logging messages about empty response bodies which suggested these were problems. In some situations (e.g. deletes), this can be a desired behavior, so we remove the messages.