### PR TITLE
Vocabulary App for V2 and V3

### DIFF
--- a/apps/vocabulary/main.go
+++ b/apps/vocabulary/main.go
@@ -23,8 +23,6 @@ import (
 
 	"github.com/golang/protobuf/jsonpb"
 	metrics "github.com/googleapis/gnostic/metrics"
-	openapi_v2 "github.com/googleapis/gnostic/openapiv2"
-	openapi_v3 "github.com/googleapis/gnostic/openapiv3"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -38,12 +36,6 @@ func fillProtoStructures(m map[string]int) []*metrics.WordCount {
 		counts = append(counts, temp)
 	}
 	return counts
-}
-func runV2(document *openapi_v2.Document) {
-
-}
-func runV3(document *openapi_v3.Document) {
-
 }
 
 func main() {
@@ -62,6 +54,7 @@ func main() {
 	var properties map[string]int
 	properties = make(map[string]int)
 
+	//Temporary, for now using filename ot check file type
 	version_flag := strings.Contains(args[0], "swagger")
 	switch version_flag {
 	case true:
@@ -70,7 +63,7 @@ func main() {
 			log.Printf("Error reading %s.", args[0])
 			os.Exit(1)
 		}
-		processDocument(document, schemas, operationId, names, properties)
+		processDocumentV2(document, schemas, operationId, names, properties)
 	default:
 		document, err := readDocumentFromFileWithNameV3(args[0])
 		if err != nil {

--- a/apps/vocabulary/main.go
+++ b/apps/vocabulary/main.go
@@ -19,95 +19,14 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/golang/protobuf/jsonpb"
-	"github.com/golang/protobuf/proto"
-
 	metrics "github.com/googleapis/gnostic/metrics"
 	openapi_v2 "github.com/googleapis/gnostic/openapiv2"
+	openapi_v3 "github.com/googleapis/gnostic/openapiv3"
+	"google.golang.org/protobuf/proto"
 )
-
-func readDocumentFromFileWithName(filename string) (*openapi_v2.Document, error) {
-	data, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return nil, err
-	}
-	document := &openapi_v2.Document{}
-	err = proto.Unmarshal(data, document)
-	if err != nil {
-		return nil, err
-	}
-	return document, nil
-
-}
-
-func processDocument(document *openapi_v2.Document, schemas map[string]int, operationId map[string]int, names map[string]int, properties map[string]int) {
-	if document.Definitions != nil {
-		for _, pair := range document.Definitions.AdditionalProperties {
-			schemas[pair.Name] += 1
-			processSchema(pair.Value, properties)
-		}
-	}
-	for _, pair := range document.Paths.Path {
-		v := pair.Value
-		if v.Get != nil {
-			processOperation(v.Get, operationId, names)
-		}
-		if v.Post != nil {
-			processOperation(v.Post, operationId, names)
-		}
-		if v.Put != nil {
-			processOperation(v.Put, operationId, names)
-		}
-		if v.Patch != nil {
-			processOperation(v.Patch, operationId, names)
-		}
-		if v.Delete != nil {
-			processOperation(v.Delete, operationId, names)
-		}
-	}
-}
-
-func processOperation(operation *openapi_v2.Operation, operationId map[string]int, names map[string]int) {
-	if operation.OperationId != "" {
-		operationId[operation.OperationId] += 1
-	}
-	for _, item := range operation.Parameters {
-		switch t := item.Oneof.(type) {
-		case *openapi_v2.ParametersItem_Parameter:
-			switch t2 := t.Parameter.Oneof.(type) {
-			case *openapi_v2.Parameter_BodyParameter:
-				names[t2.BodyParameter.Name] += 1
-			case *openapi_v2.Parameter_NonBodyParameter:
-				nonBodyParam := t2.NonBodyParameter
-				processOperationParamaters(operation, names, nonBodyParam)
-
-			}
-		}
-	}
-}
-
-func processOperationParamaters(operation *openapi_v2.Operation, names map[string]int, nonBodyParam *openapi_v2.NonBodyParameter) {
-	switch t3 := nonBodyParam.Oneof.(type) {
-	case *openapi_v2.NonBodyParameter_FormDataParameterSubSchema:
-		names[t3.FormDataParameterSubSchema.Name] += 1
-	case *openapi_v2.NonBodyParameter_HeaderParameterSubSchema:
-		names[t3.HeaderParameterSubSchema.Name] += 1
-	case *openapi_v2.NonBodyParameter_PathParameterSubSchema:
-		names[t3.PathParameterSubSchema.Name] += 1
-	case *openapi_v2.NonBodyParameter_QueryParameterSubSchema:
-		names[t3.QueryParameterSubSchema.Name] += 1
-	}
-}
-
-func processSchema(schema *openapi_v2.Schema, properties map[string]int) {
-	if schema.Properties == nil {
-		return
-	}
-	for _, pair := range schema.Properties.AdditionalProperties {
-		properties[pair.Name] += 1
-	}
-}
 
 func fillProtoStructures(m map[string]int) []*metrics.WordCount {
 	counts := make([]*metrics.WordCount, 0)
@@ -120,17 +39,16 @@ func fillProtoStructures(m map[string]int) []*metrics.WordCount {
 	}
 	return counts
 }
+func runV2(document *openapi_v2.Document) {
+
+}
+func runV3(document *openapi_v3.Document) {
+
+}
 
 func main() {
 	flag.Parse()
 	args := flag.Args()
-
-	document, err := readDocumentFromFileWithName(args[0])
-
-	if err != nil {
-		log.Printf("Error reading %s. This sample expects OpenAPI v2.", args[0])
-		os.Exit(1)
-	}
 
 	var schemas map[string]int
 	schemas = make(map[string]int)
@@ -144,7 +62,24 @@ func main() {
 	var properties map[string]int
 	properties = make(map[string]int)
 
-	processDocument(document, schemas, operationId, names, properties)
+	version_flag := strings.Contains(args[0], "swagger")
+	switch version_flag {
+	case true:
+		document, err := readDocumentFromFileWithName(args[0])
+		if err != nil {
+			log.Printf("Error reading %s.", args[0])
+			os.Exit(1)
+		}
+		processDocument(document, schemas, operationId, names, properties)
+	default:
+		document, err := readDocumentFromFileWithNameV3(args[0])
+		if err != nil {
+			log.Printf("Error reading %s.", args[0])
+			os.Exit(1)
+		}
+		processDocumentV3(document, schemas, operationId, names, properties)
+
+	}
 
 	vocab := &metrics.Vocabulary{
 		Schemas:    fillProtoStructures(schemas),

--- a/apps/vocabulary/main.go
+++ b/apps/vocabulary/main.go
@@ -54,11 +54,11 @@ func main() {
 	var properties map[string]int
 	properties = make(map[string]int)
 
-	//Temporary, for now using filename ot check file type
+	//Temporary, for now using filename to check file type
 	version_flag := strings.Contains(args[0], "swagger")
 	switch version_flag {
 	case true:
-		document, err := readDocumentFromFileWithName(args[0])
+		document, err := readDocumentFromFileWithNameV2(args[0])
 		if err != nil {
 			log.Printf("Error reading %s.", args[0])
 			os.Exit(1)

--- a/apps/vocabulary/v2Processor.go
+++ b/apps/vocabulary/v2Processor.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"io/ioutil"
+
+	"github.com/golang/protobuf/proto"
+
+	openapi_v2 "github.com/googleapis/gnostic/openapiv2"
+)
+
+func readDocumentFromFileWithName(filename string) (*openapi_v2.Document, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	document := &openapi_v2.Document{}
+	err = proto.Unmarshal(data, document)
+	if err != nil {
+		return nil, err
+	}
+	return document, nil
+
+}
+
+func processDocument(document *openapi_v2.Document, schemas map[string]int, operationId map[string]int, names map[string]int, properties map[string]int) {
+	if document.Definitions != nil {
+		for _, pair := range document.Definitions.AdditionalProperties {
+			schemas[pair.Name] += 1
+			processSchema(pair.Value, properties)
+		}
+	}
+	for _, pair := range document.Paths.Path {
+		v := pair.Value
+		if v.Get != nil {
+			processOperation(v.Get, operationId, names)
+		}
+		if v.Post != nil {
+			processOperation(v.Post, operationId, names)
+		}
+		if v.Put != nil {
+			processOperation(v.Put, operationId, names)
+		}
+		if v.Patch != nil {
+			processOperation(v.Patch, operationId, names)
+		}
+		if v.Delete != nil {
+			processOperation(v.Delete, operationId, names)
+		}
+	}
+}
+
+func processOperation(operation *openapi_v2.Operation, operationId map[string]int, names map[string]int) {
+	if operation.OperationId != "" {
+		operationId[operation.OperationId] += 1
+	}
+	for _, item := range operation.Parameters {
+		switch t := item.Oneof.(type) {
+		case *openapi_v2.ParametersItem_Parameter:
+			switch t2 := t.Parameter.Oneof.(type) {
+			case *openapi_v2.Parameter_BodyParameter:
+				names[t2.BodyParameter.Name] += 1
+			case *openapi_v2.Parameter_NonBodyParameter:
+				nonBodyParam := t2.NonBodyParameter
+				processOperationParamaters(operation, names, nonBodyParam)
+
+			}
+		}
+	}
+}
+
+func processOperationParamaters(operation *openapi_v2.Operation, names map[string]int, nonBodyParam *openapi_v2.NonBodyParameter) {
+	switch t3 := nonBodyParam.Oneof.(type) {
+	case *openapi_v2.NonBodyParameter_FormDataParameterSubSchema:
+		names[t3.FormDataParameterSubSchema.Name] += 1
+	case *openapi_v2.NonBodyParameter_HeaderParameterSubSchema:
+		names[t3.HeaderParameterSubSchema.Name] += 1
+	case *openapi_v2.NonBodyParameter_PathParameterSubSchema:
+		names[t3.PathParameterSubSchema.Name] += 1
+	case *openapi_v2.NonBodyParameter_QueryParameterSubSchema:
+		names[t3.QueryParameterSubSchema.Name] += 1
+	}
+}
+
+func processSchema(schema *openapi_v2.Schema, properties map[string]int) {
+	if schema.Properties == nil {
+		return
+	}
+	for _, pair := range schema.Properties.AdditionalProperties {
+		properties[pair.Name] += 1
+	}
+}

--- a/apps/vocabulary/v2Processor.go
+++ b/apps/vocabulary/v2Processor.go
@@ -8,7 +8,7 @@ import (
 	openapi_v2 "github.com/googleapis/gnostic/openapiv2"
 )
 
-func readDocumentFromFileWithName(filename string) (*openapi_v2.Document, error) {
+func readDocumentFromFileWithNameV2(filename string) (*openapi_v2.Document, error) {
 	data, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err

--- a/apps/vocabulary/v2Processor.go
+++ b/apps/vocabulary/v2Processor.go
@@ -22,34 +22,34 @@ func readDocumentFromFileWithName(filename string) (*openapi_v2.Document, error)
 
 }
 
-func processDocument(document *openapi_v2.Document, schemas map[string]int, operationId map[string]int, names map[string]int, properties map[string]int) {
+func processDocumentV2(document *openapi_v2.Document, schemas map[string]int, operationId map[string]int, names map[string]int, properties map[string]int) {
 	if document.Definitions != nil {
 		for _, pair := range document.Definitions.AdditionalProperties {
 			schemas[pair.Name] += 1
-			processSchema(pair.Value, properties)
+			processSchemaV2(pair.Value, properties)
 		}
 	}
 	for _, pair := range document.Paths.Path {
 		v := pair.Value
 		if v.Get != nil {
-			processOperation(v.Get, operationId, names)
+			processOperationV2(v.Get, operationId, names)
 		}
 		if v.Post != nil {
-			processOperation(v.Post, operationId, names)
+			processOperationV2(v.Post, operationId, names)
 		}
 		if v.Put != nil {
-			processOperation(v.Put, operationId, names)
+			processOperationV2(v.Put, operationId, names)
 		}
 		if v.Patch != nil {
-			processOperation(v.Patch, operationId, names)
+			processOperationV2(v.Patch, operationId, names)
 		}
 		if v.Delete != nil {
-			processOperation(v.Delete, operationId, names)
+			processOperationV2(v.Delete, operationId, names)
 		}
 	}
 }
 
-func processOperation(operation *openapi_v2.Operation, operationId map[string]int, names map[string]int) {
+func processOperationV2(operation *openapi_v2.Operation, operationId map[string]int, names map[string]int) {
 	if operation.OperationId != "" {
 		operationId[operation.OperationId] += 1
 	}
@@ -61,14 +61,14 @@ func processOperation(operation *openapi_v2.Operation, operationId map[string]in
 				names[t2.BodyParameter.Name] += 1
 			case *openapi_v2.Parameter_NonBodyParameter:
 				nonBodyParam := t2.NonBodyParameter
-				processOperationParamaters(operation, names, nonBodyParam)
+				processOperationParamatersV2(operation, names, nonBodyParam)
 
 			}
 		}
 	}
 }
 
-func processOperationParamaters(operation *openapi_v2.Operation, names map[string]int, nonBodyParam *openapi_v2.NonBodyParameter) {
+func processOperationParamatersV2(operation *openapi_v2.Operation, names map[string]int, nonBodyParam *openapi_v2.NonBodyParameter) {
 	switch t3 := nonBodyParam.Oneof.(type) {
 	case *openapi_v2.NonBodyParameter_FormDataParameterSubSchema:
 		names[t3.FormDataParameterSubSchema.Name] += 1
@@ -81,7 +81,7 @@ func processOperationParamaters(operation *openapi_v2.Operation, names map[strin
 	}
 }
 
-func processSchema(schema *openapi_v2.Schema, properties map[string]int) {
+func processSchemaV2(schema *openapi_v2.Schema, properties map[string]int) {
 	if schema.Properties == nil {
 		return
 	}

--- a/apps/vocabulary/v3Processor.go
+++ b/apps/vocabulary/v3Processor.go
@@ -24,7 +24,7 @@ func readDocumentFromFileWithNameV3(filename string) (*openapi_v3.Document, erro
 
 func processDocumentV3(document *openapi_v3.Document, schemas map[string]int, operationId map[string]int, names map[string]int, properties map[string]int) {
 	if document.Components != nil {
-		processSchemaV3(document.Components, schemas, properties)
+		processComponentsV3(document.Components, schemas, properties)
 
 	}
 	for _, pair := range document.Paths.Path {
@@ -59,7 +59,14 @@ func processOperationV3(operation *openapi_v3.Operation, operationId map[string]
 	}
 }
 
-func processSchemaV3(components *openapi_v3.Components, schemas map[string]int, properties map[string]int) {
+func processComponentsV3(components *openapi_v3.Components, schemas map[string]int, properties map[string]int) {
+	processParametersV3(components, schemas, properties)
+	processSchemasV3(components, schemas)
+	processResponsesV3(components, schemas)
+
+}
+
+func processParametersV3(components *openapi_v3.Components, schemas map[string]int, properties map[string]int) {
 	for _, pair := range components.Parameters.AdditionalProperties {
 		schemas[pair.Name] += 1
 		switch t := pair.Value.Oneof.(type) {
@@ -67,9 +74,15 @@ func processSchemaV3(components *openapi_v3.Components, schemas map[string]int, 
 			properties[t.Parameter.Name] += 1
 		}
 	}
+}
+
+func processSchemasV3(components *openapi_v3.Components, schemas map[string]int) {
 	for _, pair := range components.Schemas.AdditionalProperties {
 		schemas[pair.Name] += 1
 	}
+}
+
+func processResponsesV3(components *openapi_v3.Components, schemas map[string]int) {
 	for _, pair := range components.Responses.AdditionalProperties {
 		schemas[pair.Name] += 1
 	}

--- a/apps/vocabulary/v3Processor.go
+++ b/apps/vocabulary/v3Processor.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"io/ioutil"
+
+	"github.com/golang/protobuf/proto"
+
+	openapi_v3 "github.com/googleapis/gnostic/openapiv3"
+)
+
+func readDocumentFromFileWithNameV3(filename string) (*openapi_v3.Document, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	document := &openapi_v3.Document{}
+	err = proto.Unmarshal(data, document)
+	if err != nil {
+		return nil, err
+	}
+	return document, nil
+
+}
+
+func processDocumentV3(document *openapi_v3.Document, schemas map[string]int, operationId map[string]int, names map[string]int, properties map[string]int) {
+	if document.Components != nil {
+		for _, pair := range document.Components.Parameters.AdditionalProperties {
+			schemas[pair.Name] += 1
+			switch t := pair.Value.Oneof.(type) {
+			case *openapi_v3.ParameterOrReference_Parameter:
+				properties[t.Parameter.Name] += 1
+			}
+		}
+	}
+	for _, pair := range document.Paths.Path {
+		v := pair.Value
+		if v.Get != nil {
+			processOperationV3(v.Get, operationId, names)
+		}
+		if v.Post != nil {
+			processOperationV3(v.Post, operationId, names)
+		}
+		if v.Put != nil {
+			processOperationV3(v.Put, operationId, names)
+		}
+		if v.Patch != nil {
+			processOperationV3(v.Patch, operationId, names)
+		}
+		if v.Delete != nil {
+			processOperationV3(v.Delete, operationId, names)
+		}
+	}
+}
+
+func processOperationV3(operation *openapi_v3.Operation, operationId map[string]int, names map[string]int) {
+	if operation.OperationId != "" {
+		operationId[operation.OperationId] += 1
+	}
+	for _, item := range operation.Parameters {
+		switch t := item.Oneof.(type) {
+		case *openapi_v3.ParameterOrReference_Parameter:
+			names[t.Parameter.Name] += 1
+		}
+	}
+}

--- a/apps/vocabulary/v3Processor.go
+++ b/apps/vocabulary/v3Processor.go
@@ -24,13 +24,8 @@ func readDocumentFromFileWithNameV3(filename string) (*openapi_v3.Document, erro
 
 func processDocumentV3(document *openapi_v3.Document, schemas map[string]int, operationId map[string]int, names map[string]int, properties map[string]int) {
 	if document.Components != nil {
-		for _, pair := range document.Components.Parameters.AdditionalProperties {
-			schemas[pair.Name] += 1
-			switch t := pair.Value.Oneof.(type) {
-			case *openapi_v3.ParameterOrReference_Parameter:
-				properties[t.Parameter.Name] += 1
-			}
-		}
+		processSchemaV3(document.Components, schemas, properties)
+
 	}
 	for _, pair := range document.Paths.Path {
 		v := pair.Value
@@ -61,5 +56,21 @@ func processOperationV3(operation *openapi_v3.Operation, operationId map[string]
 		case *openapi_v3.ParameterOrReference_Parameter:
 			names[t.Parameter.Name] += 1
 		}
+	}
+}
+
+func processSchemaV3(components *openapi_v3.Components, schemas map[string]int, properties map[string]int) {
+	for _, pair := range components.Parameters.AdditionalProperties {
+		schemas[pair.Name] += 1
+		switch t := pair.Value.Oneof.(type) {
+		case *openapi_v3.ParameterOrReference_Parameter:
+			properties[t.Parameter.Name] += 1
+		}
+	}
+	for _, pair := range components.Schemas.AdditionalProperties {
+		schemas[pair.Name] += 1
+	}
+	for _, pair := range components.Responses.AdditionalProperties {
+		schemas[pair.Name] += 1
 	}
 }


### PR DESCRIPTION
This pull request builds upon my previous one by including functionality for v3 APIs. The structure now for the vocabulary app is as follows: main.go receives an API description, determines which API version it received and then calls one of the two following files: v2Processor.go or v3Processor.go. Both files follow the same flow but are specific to the structure of that API's version. 