### PR TITLE
clear the testcache in "make test"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,6 @@ all:
 	cd extensions/sample; make
 
 test:
+	# since some tests call separately-built binaries, clear the cache to ensure all get run
+	go clean -testcache
 	go test ./... -v


### PR DESCRIPTION
Some tests run separately-built binaries, and when the sources for these change, the tests don't always get rerun (due to the [Go test cache](https://stackoverflow.com/questions/48882691/force-retesting-or-disable-test-caching)). To fix this, this PR adds a `go clean -testcache` at the beginning of `make test`.