### PR TITLE
Adding an additional case for ScalarNodes with tag "!!int".

### DIFF
--- a/compiler/helpers.go
+++ b/compiler/helpers.go
@@ -172,6 +172,8 @@ func StringForScalarNode(node *yaml.Node) (string, bool) {
 	switch node.Kind {
 	case yaml.ScalarNode:
 		switch node.Tag {
+		case "!!int":
+			return node.Value, true
 		case "!!str":
 			return node.Value, true
 		case "!!null":


### PR DESCRIPTION
Tests in gnostic-grpc are currently failing due to [PR194](https://github.com/googleapis/gnostic/pull/194).
Currently, `ResponseOrRefernce` is not properly constructed, because gnostic does [not recognize](https://github.com/googleapis/gnostic/blob/ce2874882b96283118ceb88bf3b651e37636963e/openapiv3/OpenAPIv3.go#L3726) that a yaml node can also have the tag "!!int".

This PR fixes all test cases in gnostic-grpc.