### PR TITLE
ToRawInfo functions return null-valued nodes instead of nil

### DIFF
--- a/compiler/helpers.go
+++ b/compiler/helpers.go
@@ -243,6 +243,15 @@ func InvalidKeysInMap(m *yaml.Node, allowedKeys []string, allowedPatterns []*reg
 	return invalidKeys
 }
 
+// NewNullNode creates a new Null node.
+func NewNullNode() *yaml.Node {
+	node := &yaml.Node{
+		Kind: yaml.ScalarNode,
+		Tag:  "!!null",
+	}
+	return node
+}
+
 // NewMappingNode creates a new Mapping node.
 func NewMappingNode() *yaml.Node {
 	return &yaml.Node{

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -2147,10 +2147,8 @@ func (m *Any) ToRawInfo() *yaml.Node {
 			return node.Content[0]
 		}
 		return &node
-	} else {
-		return nil
 	}
-	return nil
+	return compiler.NewNullNode()
 }
 
 // ToRawInfo returns a description of Auth suitable for JSON or YAML export.

--- a/generate-gnostic/generate-compiler.go
+++ b/generate-gnostic/generate-compiler.go
@@ -719,10 +719,8 @@ func (domain *Domain) generateToRawInfoMethodForType(code *printer.Code, typeNam
 		code.Print("		return node.Content[0]")
 		code.Print("	}")
 		code.Print("	return &node")
-		code.Print("} else {")
-		code.Print("	return nil")
 		code.Print("}")
-		code.Print("return nil")
+		code.Print("return compiler.NewNullNode()")
 	} else if typeName == "StringArray" {
 		code.Print("return compiler.NewSequenceNodeForStringArray(m.Value)")
 	} else if typeModel.OneOfWrapper {
@@ -749,7 +747,7 @@ func (domain *Domain) generateToRawInfoMethodForType(code *printer.Code, typeNam
 				code.Print("}")
 			}
 		}
-		code.Print("return nil")
+		code.Print("return compiler.NewNullNode()")
 	} else {
 		code.Print("info := compiler.NewMappingNode()")
 		code.Print("if m == nil {return info}")

--- a/openapiv2/OpenAPIv2.go
+++ b/openapiv2/OpenAPIv2.go
@@ -6817,7 +6817,7 @@ func (m *AdditionalPropertiesItem) ToRawInfo() *yaml.Node {
 	if v1, ok := m.GetOneof().(*AdditionalPropertiesItem_Boolean); ok {
 		return compiler.NewScalarNodeForBool(v1.Boolean)
 	}
-	return nil
+	return compiler.NewNullNode()
 }
 
 // ToRawInfo returns a description of Any suitable for JSON or YAML export.
@@ -6830,10 +6830,8 @@ func (m *Any) ToRawInfo() *yaml.Node {
 			return node.Content[0]
 		}
 		return &node
-	} else {
-		return nil
 	}
-	return nil
+	return compiler.NewNullNode()
 }
 
 // ToRawInfo returns a description of ApiKeySecurity suitable for JSON or YAML export.
@@ -7716,7 +7714,7 @@ func (m *NonBodyParameter) ToRawInfo() *yaml.Node {
 	if v3 != nil {
 		return v3.ToRawInfo()
 	}
-	return nil
+	return compiler.NewNullNode()
 }
 
 // ToRawInfo returns a description of Oauth2AccessCodeSecurity suitable for JSON or YAML export.
@@ -7944,7 +7942,7 @@ func (m *Parameter) ToRawInfo() *yaml.Node {
 	if v1 != nil {
 		return v1.ToRawInfo()
 	}
-	return nil
+	return compiler.NewNullNode()
 }
 
 // ToRawInfo returns a description of ParameterDefinitions suitable for JSON or YAML export.
@@ -7976,7 +7974,7 @@ func (m *ParametersItem) ToRawInfo() *yaml.Node {
 	if v1 != nil {
 		return v1.ToRawInfo()
 	}
-	return nil
+	return compiler.NewNullNode()
 }
 
 // ToRawInfo returns a description of PathItem suitable for JSON or YAML export.
@@ -8425,7 +8423,7 @@ func (m *ResponseValue) ToRawInfo() *yaml.Node {
 	if v1 != nil {
 		return v1.ToRawInfo()
 	}
-	return nil
+	return compiler.NewNullNode()
 }
 
 // ToRawInfo returns a description of Responses suitable for JSON or YAML export.
@@ -8618,7 +8616,7 @@ func (m *SchemaItem) ToRawInfo() *yaml.Node {
 	if v1 != nil {
 		return v1.ToRawInfo()
 	}
-	return nil
+	return compiler.NewNullNode()
 }
 
 // ToRawInfo returns a description of SecurityDefinitions suitable for JSON or YAML export.
@@ -8670,7 +8668,7 @@ func (m *SecurityDefinitionsItem) ToRawInfo() *yaml.Node {
 	if v5 != nil {
 		return v5.ToRawInfo()
 	}
-	return nil
+	return compiler.NewNullNode()
 }
 
 // ToRawInfo returns a description of SecurityRequirement suitable for JSON or YAML export.

--- a/openapiv3/OpenAPIv3.go
+++ b/openapiv3/OpenAPIv3.go
@@ -6635,7 +6635,7 @@ func (m *AdditionalPropertiesItem) ToRawInfo() *yaml.Node {
 	if v1, ok := m.GetOneof().(*AdditionalPropertiesItem_Boolean); ok {
 		return compiler.NewScalarNodeForBool(v1.Boolean)
 	}
-	return nil
+	return compiler.NewNullNode()
 }
 
 // ToRawInfo returns a description of Any suitable for JSON or YAML export.
@@ -6648,10 +6648,8 @@ func (m *Any) ToRawInfo() *yaml.Node {
 			return node.Content[0]
 		}
 		return &node
-	} else {
-		return nil
 	}
-	return nil
+	return compiler.NewNullNode()
 }
 
 // ToRawInfo returns a description of AnyOrExpression suitable for JSON or YAML export.
@@ -6668,7 +6666,7 @@ func (m *AnyOrExpression) ToRawInfo() *yaml.Node {
 	if v1 != nil {
 		return v1.ToRawInfo()
 	}
-	return nil
+	return compiler.NewNullNode()
 }
 
 // ToRawInfo returns a description of Callback suitable for JSON or YAML export.
@@ -6706,7 +6704,7 @@ func (m *CallbackOrReference) ToRawInfo() *yaml.Node {
 	if v1 != nil {
 		return v1.ToRawInfo()
 	}
-	return nil
+	return compiler.NewNullNode()
 }
 
 // ToRawInfo returns a description of CallbacksOrReferences suitable for JSON or YAML export.
@@ -6818,7 +6816,7 @@ func (m *DefaultType) ToRawInfo() *yaml.Node {
 	if v2, ok := m.GetOneof().(*DefaultType_String_); ok {
 		return compiler.NewScalarNodeForString(v2.String_)
 	}
-	return nil
+	return compiler.NewNullNode()
 }
 
 // ToRawInfo returns a description of Discriminator suitable for JSON or YAML export.
@@ -6991,7 +6989,7 @@ func (m *ExampleOrReference) ToRawInfo() *yaml.Node {
 	if v1 != nil {
 		return v1.ToRawInfo()
 	}
-	return nil
+	return compiler.NewNullNode()
 }
 
 // ToRawInfo returns a description of ExamplesOrReferences suitable for JSON or YAML export.
@@ -7119,7 +7117,7 @@ func (m *HeaderOrReference) ToRawInfo() *yaml.Node {
 	if v1 != nil {
 		return v1.ToRawInfo()
 	}
-	return nil
+	return compiler.NewNullNode()
 }
 
 // ToRawInfo returns a description of HeadersOrReferences suitable for JSON or YAML export.
@@ -7270,7 +7268,7 @@ func (m *LinkOrReference) ToRawInfo() *yaml.Node {
 	if v1 != nil {
 		return v1.ToRawInfo()
 	}
-	return nil
+	return compiler.NewNullNode()
 }
 
 // ToRawInfo returns a description of LinksOrReferences suitable for JSON or YAML export.
@@ -7791,7 +7789,7 @@ func (m *ParameterOrReference) ToRawInfo() *yaml.Node {
 	if v1 != nil {
 		return v1.ToRawInfo()
 	}
-	return nil
+	return compiler.NewNullNode()
 }
 
 // ToRawInfo returns a description of ParametersOrReferences suitable for JSON or YAML export.
@@ -7987,7 +7985,7 @@ func (m *RequestBodyOrReference) ToRawInfo() *yaml.Node {
 	if v1 != nil {
 		return v1.ToRawInfo()
 	}
-	return nil
+	return compiler.NewNullNode()
 }
 
 // ToRawInfo returns a description of Response suitable for JSON or YAML export.
@@ -8034,7 +8032,7 @@ func (m *ResponseOrReference) ToRawInfo() *yaml.Node {
 	if v1 != nil {
 		return v1.ToRawInfo()
 	}
-	return nil
+	return compiler.NewNullNode()
 }
 
 // ToRawInfo returns a description of Responses suitable for JSON or YAML export.
@@ -8269,7 +8267,7 @@ func (m *SchemaOrReference) ToRawInfo() *yaml.Node {
 	if v1 != nil {
 		return v1.ToRawInfo()
 	}
-	return nil
+	return compiler.NewNullNode()
 }
 
 // ToRawInfo returns a description of SchemasOrReferences suitable for JSON or YAML export.
@@ -8362,7 +8360,7 @@ func (m *SecuritySchemeOrReference) ToRawInfo() *yaml.Node {
 	if v1 != nil {
 		return v1.ToRawInfo()
 	}
-	return nil
+	return compiler.NewNullNode()
 }
 
 // ToRawInfo returns a description of SecuritySchemesOrReferences suitable for JSON or YAML export.
@@ -8463,7 +8461,7 @@ func (m *SpecificationExtension) ToRawInfo() *yaml.Node {
 	if v2, ok := m.GetOneof().(*SpecificationExtension_String_); ok {
 		return compiler.NewScalarNodeForString(v2.String_)
 	}
-	return nil
+	return compiler.NewNullNode()
 }
 
 // ToRawInfo returns a description of StringArray suitable for JSON or YAML export.


### PR DESCRIPTION
This fixes crashes in the yaml.v3 export functions that were discovered for newly-added specs in public directories.